### PR TITLE
Update Swift package version and platform versions

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-15-beta
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,13 +12,13 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-15-beta
 
     steps:
     - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: 16-beta
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,13 @@
-// swift-tools-version:5.8
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
     name: "NanoTDF",
     platforms: [
-        .macOS(.v13), // Update to the latest macOS version
-        .iOS(.v16), // Update to the latest iOS version
-        .tvOS(.v16), // Update to the latest tvOS version
-        .watchOS(.v9), // Update to the latest watchOS version
+        .macOS(.v15),
+        .iOS(.v18),
+        .tvOS(.v18),
+        .watchOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
The Swift tools version has been updated to 6.0 in the Package.swift. Additionally, the platform versions for macOS, iOS, tvOS, and watchOS have been upgraded to their respective latest versions. The GitHub workflow has been also adjusted to run on macOS 15 beta and Xcode 16 beta.