### PR TITLE
KASWebSocket kasUrl

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/OpenTDFKitTests.xcbaseline/3169F6C6-AD33-4C10-8516-0CD808F6EB48.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/OpenTDFKitTests.xcbaseline/3169F6C6-AD33-4C10-8516-0CD808F6EB48.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>KASWebsocketTests</key>
+		<dict>
+			<key>testEncryptDecrypt()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1650206.736600</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>17757462.366800</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_CPU.time</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.325406</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_Memory.physical</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>3257.190400</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/OpenTDFKitTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/OpenTDFKitTests.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>3169F6C6-AD33-4C10-8516-0CD808F6EB48</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Max</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>Mac13,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64e</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Refactor KASWebSocket initialization and enhance error handling

This commit refactors the KASWebSocket's initializer to accept a URL parameter, enabling flexibility in the WebSocket endpoint. It addresses previous hard-coded "kasUrl" in the connect() method. Also, it introduces better error handling to manage scenarios where the received data isn't equal to the expected 93 bytes. Tests have been updated to comply with these changes. Additionally, new performance baselines for KASWebsocketTests have been established.