### PR TITLE
WebSocketConnectionState

### DIFF
--- a/OpenTDFKit/KASWebSocket.swift
+++ b/OpenTDFKit/KASWebSocket.swift
@@ -8,6 +8,16 @@ public enum WebSocketConnectionState {
     case connected
 }
 
+extension WebSocketConnectionState: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .disconnected: "Disconnected"
+        case .connecting: "Connecting"
+        case .connected: "Connected"
+        }
+    }
+}
+
 public class KASWebSocket {
     private var webSocketTask: URLSessionWebSocketTask?
     private var urlSession: URLSession?


### PR DESCRIPTION
Add CustomStringConvertible to WebSocketConnectionState

Implement the CustomStringConvertible protocol for the WebSocketConnectionState enum to provide a human-readable string representation of its values. This enhances the debugging output and improves code readability.