### PR TITLE
Make `toData` methods public

### DIFF
--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -82,7 +82,7 @@ public class BinaryParser {
         // if no policy added then no read
         // Note 3.4.2.3.2 Body for Embedded Policy states Minimum Length is 1
         if contentLength == 0 {
-            return EmbeddedPolicyBody(length: 1, body: Data([0x00]), keyAccess: nil)
+            return EmbeddedPolicyBody(body: Data([0x00]), keyAccess: nil)
         }
 
         guard let plaintextCiphertext = read(length: Int(contentLength)) else {
@@ -92,7 +92,7 @@ public class BinaryParser {
         // Policy Key Access
         let keyAccess = policyType == .embeddedEncryptedWithPolicyKeyAccess ? readPolicyKeyAccess(bindingMode: bindingMode) : nil
 
-        return EmbeddedPolicyBody(length: plaintextCiphertext.count, body: plaintextCiphertext, keyAccess: keyAccess)
+        return EmbeddedPolicyBody(body: plaintextCiphertext, keyAccess: keyAccess)
     }
 
     func readEccAndBindingMode() -> PolicyBindingConfig? {

--- a/OpenTDFKit/NanoTDF.swift
+++ b/OpenTDFKit/NanoTDF.swift
@@ -159,7 +159,7 @@ public struct ResourceLocator: Sendable {
         self.body = body
     }
 
-    func toData() -> Data {
+    public func toData() -> Data {
         var data = Data()
         data.append(protocolEnum.rawValue)
         if let bodyData = body.data(using: .utf8) {
@@ -191,7 +191,7 @@ public struct Policy: Sendable {
         self.binding = binding
     }
 
-    func toData() -> Data {
+    public func toData() -> Data {
         var data = Data()
         data.append(type.rawValue)
         switch type {
@@ -212,13 +212,19 @@ public struct Policy: Sendable {
 }
 
 public struct EmbeddedPolicyBody: Sendable {
-    public let length: Int
     public let body: Data
     public let keyAccess: PolicyKeyAccess?
 
-    func toData() -> Data {
+    public init(body: Data, keyAccess: PolicyKeyAccess? = nil) {
+        self.body = body
+        self.keyAccess = keyAccess
+    }
+
+    public func toData() -> Data {
         var data = Data()
-        data.append(UInt8(body.count)) // length
+        let bodyLength = UInt16(body.count)
+        data.append(UInt8((bodyLength >> 8) & 0xFF)) // length high byte
+        data.append(UInt8(bodyLength & 0xFF)) // length low byte
         data.append(body)
         if let keyAccess {
             data.append(keyAccess.toData())


### PR DESCRIPTION
Changed the `toData` methods to public to ensure accessibility across different modules. Introduced geofence-related structures like `Coordinate3D`, `Geofence3D`, and their respective test cases to validate geofence functionalities.