### PR TITLE
Fix NanoTDF spec compliance and Policy KAS key handling

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -19,6 +19,9 @@ jobs:
         
       - name: Install Swift 6.2
         run: |
+          # Remove any existing Swift installation
+          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
+
           # Install dependencies
           sudo apt-get update
           sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
@@ -27,11 +30,22 @@ jobs:
           wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
           tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
           sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+
+          # Create symlinks for system-wide access
+          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
+          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
+          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
+          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
+          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
+
+          # Add to PATH for this step and future steps
           echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-          export PATH="/usr/share/swift/usr/bin:$PATH"
         
-      - name: Print Swift version
-        run: swift --version
+      - name: Verify Swift 6.2 installation
+        run: |
+          swift --version
+          which swift
+          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
           
       - name: Cache SwiftFormat
         id: cache-swiftformat
@@ -64,6 +78,9 @@ jobs:
         
       - name: Install Swift 6.2
         run: |
+          # Remove any existing Swift installation
+          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
+
           # Install dependencies
           sudo apt-get update
           sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
@@ -72,11 +89,22 @@ jobs:
           wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
           tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
           sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+
+          # Create symlinks for system-wide access
+          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
+          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
+          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
+          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
+          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
+
+          # Add to PATH for this step and future steps
           echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-          export PATH="/usr/share/swift/usr/bin:$PATH"
         
-      - name: Print Swift version
-        run: swift --version
+      - name: Verify Swift 6.2 installation
+        run: |
+          swift --version
+          which swift
+          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
           
       - name: Cache Swift packages
         id: cache-swift
@@ -103,6 +131,9 @@ jobs:
 
       - name: Install Swift 6.2
         run: |
+          # Remove any existing Swift installation
+          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
+
           # Install dependencies
           sudo apt-get update
           sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
@@ -111,11 +142,22 @@ jobs:
           wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
           tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
           sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
-          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-          export PATH="/usr/share/swift/usr/bin:$PATH"
 
-      - name: Print Swift version
-        run: swift --version
+          # Create symlinks for system-wide access
+          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
+          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
+          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
+          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
+          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
+
+          # Add to PATH for this step and future steps
+          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+
+      - name: Verify Swift 6.2 installation
+        run: |
+          swift --version
+          which swift
+          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
 
       - name: Cache Swift packages
         id: cache-swift
@@ -139,6 +181,9 @@ jobs:
         
       - name: Install Swift 6.2
         run: |
+          # Remove any existing Swift installation
+          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
+
           # Install dependencies
           sudo apt-get update
           sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
@@ -147,11 +192,22 @@ jobs:
           wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
           tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
           sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+
+          # Create symlinks for system-wide access
+          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
+          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
+          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
+          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
+          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
+
+          # Add to PATH for this step and future steps
           echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-          export PATH="/usr/share/swift/usr/bin:$PATH"
         
-      - name: Print Swift version
-        run: swift --version
+      - name: Verify Swift 6.2 installation
+        run: |
+          swift --version
+          which swift
+          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
           
       - name: Cache Swift packages
         id: cache-swift

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -12,57 +12,21 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Install Swift 6.2
-        run: |
-          # Remove any existing Swift installation
-          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
-
-          # Install dependencies
-          sudo apt-get update
-          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
-
-          # Download and install Swift 6.2
-          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
-
-          # Create symlinks for system-wide access
-          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
-          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
-          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
-          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
-          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
-
-          # Add to PATH for this step and future steps
-          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-        
-      - name: Verify Swift 6.2 installation
-        run: |
-          swift --version
-          which swift
-          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
-          
-      - name: Cache SwiftFormat
-        id: cache-swiftformat
-        uses: actions/cache@v4
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          path: /usr/local/bin/swiftformat
-          key: ${{ runner.os }}-swiftformat-0.54.0
-          restore-keys: |
-            ${{ runner.os }}-swiftformat-
-
+          xcode-version: latest-stable
+        
+      - name: Print Swift version
+        run: swift --version
+          
       - name: Install SwiftFormat
-        if: steps.cache-swiftformat.outputs.cache-hit != 'true'
-        run: |
-          git clone --depth 1 --branch 0.54.0 https://github.com/nicklockwood/SwiftFormat.git
-          cd SwiftFormat
-          swift build -c release --disable-sandbox
-          sudo cp .build/release/swiftformat /usr/local/bin/
+        run: brew install swiftformat
 
       - name: Run SwiftFormat
         run: swiftformat --swiftversion 6.2 . --lint
@@ -71,40 +35,18 @@ jobs:
 #        run: swiftlint --strict
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Install Swift 6.2
-        run: |
-          # Remove any existing Swift installation
-          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
-
-          # Install dependencies
-          sudo apt-get update
-          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
-
-          # Download and install Swift 6.2
-          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
-
-          # Create symlinks for system-wide access
-          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
-          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
-          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
-          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
-          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
-
-          # Add to PATH for this step and future steps
-          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
         
-      - name: Verify Swift 6.2 installation
-        run: |
-          swift --version
-          which swift
-          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
+      - name: Print Swift version
+        run: swift --version
           
       - name: Cache Swift packages
         id: cache-swift
@@ -124,40 +66,18 @@ jobs:
         run: swift build -c release -v
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Swift 6.2
-        run: |
-          # Remove any existing Swift installation
-          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
-          # Install dependencies
-          sudo apt-get update
-          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
-
-          # Download and install Swift 6.2
-          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
-
-          # Create symlinks for system-wide access
-          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
-          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
-          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
-          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
-          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
-
-          # Add to PATH for this step and future steps
-          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
-
-      - name: Verify Swift 6.2 installation
-        run: |
-          swift --version
-          which swift
-          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
+      - name: Print Swift version
+        run: swift --version
 
       - name: Cache Swift packages
         id: cache-swift
@@ -174,40 +94,18 @@ jobs:
         run: swift test
 
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Install Swift 6.2
-        run: |
-          # Remove any existing Swift installation
-          sudo rm -rf /usr/bin/swift /usr/bin/swiftc
-
-          # Install dependencies
-          sudo apt-get update
-          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
-
-          # Download and install Swift 6.2
-          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
-          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
-
-          # Create symlinks for system-wide access
-          sudo ln -sf /usr/share/swift/usr/bin/swift /usr/bin/swift
-          sudo ln -sf /usr/share/swift/usr/bin/swiftc /usr/bin/swiftc
-          sudo ln -sf /usr/share/swift/usr/bin/swift-build /usr/bin/swift-build
-          sudo ln -sf /usr/share/swift/usr/bin/swift-package /usr/bin/swift-package
-          sudo ln -sf /usr/share/swift/usr/bin/swift-test /usr/bin/swift-test
-
-          # Add to PATH for this step and future steps
-          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
         
-      - name: Verify Swift 6.2 installation
-        run: |
-          swift --version
-          which swift
-          swift --version | grep -q "6.2" || (echo "Error: Swift 6.2 not properly installed" && exit 1)
+      - name: Print Swift version
+        run: swift --version
           
       - name: Cache Swift packages
         id: cache-swift

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   lint:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,30 +20,36 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6
+          swift-version: 6.2
         
       - name: Print Swift version
         run: swift --version
           
-      - name: Cache Homebrew dependencies
-        id: cache-brew
+      - name: Cache SwiftFormat
+        id: cache-swiftformat
         uses: actions/cache@v4
         with:
-          path: |
-            ~/Library/Caches/Homebrew
-            /usr/local/Homebrew
-          key: ${{ runner.os }}-brew
+          path: /usr/local/bin/swiftformat
+          key: ${{ runner.os }}-swiftformat-0.54.0
           restore-keys: |
-            ${{ runner.os }}-brew-
+            ${{ runner.os }}-swiftformat-
+
+      - name: Install SwiftFormat
+        if: steps.cache-swiftformat.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch 0.54.0 https://github.com/nicklockwood/SwiftFormat.git
+          cd SwiftFormat
+          swift build -c release --disable-sandbox
+          sudo cp .build/release/swiftformat /usr/local/bin/
 
       - name: Run SwiftFormat
-        run: swiftformat --swiftversion 6.0 . --lint
+        run: swiftformat --swiftversion 6.2 . --lint
         
 #      - name: Run SwiftLint
 #        run: swiftlint --strict
 
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,7 +57,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6
+          swift-version: 6.2
         
       - name: Print Swift version
         run: swift --version
@@ -73,36 +79,36 @@ jobs:
       - name: Build Release
         run: swift build -c release -v
 
-#  test:
-#    runs-on: macos-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v4
-#        
-#      - name: Setup Swift
-#        uses: swift-actions/setup-swift@v2
-#        with:
-#          swift-version: 6
-#        
-#      - name: Print Swift version
-#        run: swift --version
-#          
-#      - name: Cache Swift packages
-#        id: cache-swift
-#        uses: actions/cache@v4
-#        with:
-#          path: |
-#            .build
-#            ~/.swiftpm
-#          key: ${{ runner.os }}-swift-${{ hashFiles('Package.swift') }}
-#          restore-keys: |
-#            ${{ runner.os }}-swift-
-#            
-#      - name: Run tests
-#        run: swift test
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: 6.2
+
+      - name: Print Swift version
+        run: swift --version
+
+      - name: Cache Swift packages
+        id: cache-swift
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/.swiftpm
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+
+      - name: Run tests
+        run: swift test
 
   benchmark:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,7 +116,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6
+          swift-version: 6.2
         
       - name: Print Swift version
         run: swift --version

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -17,10 +17,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0"
+      - name: Install Swift 6.2
+        run: |
+          # Install dependencies
+          sudo apt-get update
+          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
+
+          # Download and install Swift 6.2
+          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+          export PATH="/usr/share/swift/usr/bin:$PATH"
         
       - name: Print Swift version
         run: swift --version
@@ -43,7 +51,7 @@ jobs:
           sudo cp .build/release/swiftformat /usr/local/bin/
 
       - name: Run SwiftFormat
-        run: swiftformat --swiftversion 6.0 . --lint
+        run: swiftformat --swiftversion 6.2 . --lint
         
 #      - name: Run SwiftLint
 #        run: swiftlint --strict
@@ -54,10 +62,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0"
+      - name: Install Swift 6.2
+        run: |
+          # Install dependencies
+          sudo apt-get update
+          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
+
+          # Download and install Swift 6.2
+          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+          export PATH="/usr/share/swift/usr/bin:$PATH"
         
       - name: Print Swift version
         run: swift --version
@@ -85,10 +101,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0"
+      - name: Install Swift 6.2
+        run: |
+          # Install dependencies
+          sudo apt-get update
+          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
+
+          # Download and install Swift 6.2
+          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+          export PATH="/usr/share/swift/usr/bin:$PATH"
 
       - name: Print Swift version
         run: swift --version
@@ -113,10 +137,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0"
+      - name: Install Swift 6.2
+        run: |
+          # Install dependencies
+          sudo apt-get update
+          sudo apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev curl
+
+          # Download and install Swift 6.2
+          wget https://download.swift.org/swift-6.2-release/ubuntu2204/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          tar xzf swift-6.2-RELEASE-ubuntu22.04.tar.gz
+          sudo mv swift-6.2-RELEASE-ubuntu22.04 /usr/share/swift
+          echo "/usr/share/swift/usr/bin" >> $GITHUB_PATH
+          export PATH="/usr/share/swift/usr/bin:$PATH"
         
       - name: Print Swift version
         run: swift --version

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6.2
+          swift-version: "6.0"
         
       - name: Print Swift version
         run: swift --version
@@ -43,7 +43,7 @@ jobs:
           sudo cp .build/release/swiftformat /usr/local/bin/
 
       - name: Run SwiftFormat
-        run: swiftformat --swiftversion 6.2 . --lint
+        run: swiftformat --swiftversion 6.0 . --lint
         
 #      - name: Run SwiftLint
 #        run: swiftlint --strict
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6.2
+          swift-version: "6.0"
         
       - name: Print Swift version
         run: swift --version
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6.2
+          swift-version: "6.0"
 
       - name: Print Swift version
         run: swift --version
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: 6.2
+          swift-version: "6.0"
         
       - name: Print Swift version
         run: swift --version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `Package.swift` defines the Swift Package targets; the default module `OpenTDFKit` exports the public API for NanoTDF operations.
+- Sources live under `OpenTDFKit/` with focused files such as `NanoTDF.swift`, `KeyStore.swift`, and `KASService.swift` governing parsing, key handling, and KAS integrations.
+- Tests reside in `OpenTDFKitTests/`, following XCTest conventions (`*Tests`, `*BenchmarkTests`) for functional, policy, and performance coverage.
+- `OpenTDFKitProfiler/` contains profiling harnesses for release builds, while `OpenTDFKit.xcodeproj` supports Xcode development.
+
+## Build, Test, and Development Commands
+- `swift build` compiles all targets with the Swift 6 toolchain.
+- `swift test` runs the full XCTest suite; add `--filter NanoTDFTests` for targeted checks.
+- `swift test --configuration release --filter "BenchmarkTests"` executes the performance suites before publishing metrics.
+- `swiftformat --swiftversion 6.2 .` enforces consistent formatting; run prior to every commit.
+- `swift run -c release OpenTDFKitProfiler` drives the profiler target when validating cryptographic hot paths.
+
+## Coding Style & Naming Conventions
+- Follow Swift API Design Guidelines: UpperCamelCase types, lowerCamelCase members, and explicit access control (`public`/`internal`) for SDK clarity.
+- Prefer value types (structs, enums) over classes unless reference semantics are required; group extensions by responsibility.
+- Indentation is 4 spaces; do not mix tabs. Keep imports minimal and alphabetized.
+- Leave explanatory comments only where algorithms or protocols are non-obvious, especially around cryptography.
+
+## Testing Guidelines
+- Add XCTest coverage adjacent to the feature in `OpenTDFKitTests/FeatureNameTests.swift`.
+- Name tests `testFunctionality_whenCondition_expectOutcome` to document intent and edge cases.
+- Place benchmarks in `*BenchmarkTests.swift`; guard runtime-heavy code with `#if !CI` when necessary.
+- Verify new tests locally with `swift test` and note any targeted filters in the PR description.
+
+## Commit & Pull Request Guidelines
+- Write imperative, concise commit messages (e.g., `Add NanoTDF concurrent (#12)`), referencing PR numbers when applicable.
+- Squash fixups before review and avoid committing generated artifacts or secrets.
+- Pull requests must include a change summary, test results, and linked GitHub issues; attach screenshots or payload samples when behavior shifts.
+- Request review from crypto maintainers for changes touching key derivation, storage, or network flows.
+- Confirm `swiftformat` and `swift test` have both run before requesting a merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ swift build
 swift build -c release
 
 # Format code (required before submitting PRs)
-swiftformat --swiftversion 6.0 .
+swiftformat --swiftversion 6.2 .
 
 # Build for profiling
 swift build -c release

--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -152,8 +152,8 @@ public class BinaryParser {
                 132
             }
         } else {
-            // GMAC Tag Binding
-            16
+            // GMAC Tag Binding - 64 bits (8 bytes) per spec section 3.3.1.3
+            8
         }
 //        print("bindingSize", bindingSize)
         return read(length: bindingSize)

--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -257,7 +257,7 @@ public class BinaryParser {
         // We represent this with an empty Data object for kasPublicKey.
         let payloadKeyAccess = PayloadKeyAccess(
             kasEndpointLocator: kas,
-            kasPublicKey: Data() // For v12, KAS public key is empty.
+            kasPublicKey: Data(), // For v12, KAS public key is empty.
         )
 
         return Header(
@@ -265,7 +265,7 @@ public class BinaryParser {
             policyBindingConfig: policyBindingConfig,
             payloadSignatureConfig: payloadSignatureConfig,
             policy: policy,
-            ephemeralPublicKey: ephemeralPublicKey
+            ephemeralPublicKey: ephemeralPublicKey,
         )
     }
 
@@ -299,7 +299,7 @@ public class BinaryParser {
             policyBindingConfig: policyBindingConfig,
             payloadSignatureConfig: payloadSignatureConfig,
             policy: policy,
-            ephemeralPublicKey: ephemeralPublicKey
+            ephemeralPublicKey: ephemeralPublicKey,
         )
     }
 

--- a/OpenTDFKit/CryptoHelper.swift
+++ b/OpenTDFKit/CryptoHelper.swift
@@ -79,7 +79,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P256 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P256.KeyAgreement.PrivateKey, publicKey: P256.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P256.KeyAgreement.PrivateKey, publicKey: P256.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         // Extract raw bytes from the SharedSecret object
         return sharedSecret.withUnsafeBytes { Data($0) }
@@ -91,7 +91,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P384 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P384.KeyAgreement.PrivateKey, publicKey: P384.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P384.KeyAgreement.PrivateKey, publicKey: P384.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         return sharedSecret.withUnsafeBytes { Data($0) }
     }
@@ -102,7 +102,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P521 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P521.KeyAgreement.PrivateKey, publicKey: P521.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P521.KeyAgreement.PrivateKey, publicKey: P521.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         return sharedSecret.withUnsafeBytes { Data($0) }
     }
@@ -110,35 +110,35 @@ actor CryptoHelper {
     /// Returns the byte representation for a given KAS key curve.
     /// - Parameter curve: The `KasKeyCurve` enum value.
     /// - Returns: The `UInt8` byte value for the curve.
-    public static func kasKeyCurveByte(for curve: KasKeyCurve) -> UInt8 {
+    static func kasKeyCurveByte(for curve: KasKeyCurve) -> UInt8 {
         curve.rawValue
     }
 
     /// Returns the `KasKeyCurve` enum value for a given byte.
     /// - Parameter byte: The `UInt8` byte value representing the curve.
     /// - Returns: An optional `KasKeyCurve` if the byte corresponds to a defined curve, otherwise `nil`.
-    public static func curve(fromKasKeyCurveByte byte: UInt8) -> KasKeyCurve? {
+    static func curve(fromKasKeyCurveByte byte: UInt8) -> KasKeyCurve? {
         KasKeyCurve(rawValue: byte)
     }
 
     /// Returns the X9.62 compressed representation of a P256 public key.
     /// - Parameter publicKey: The `P256.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P256.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P256.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
     /// Returns the X9.62 compressed representation of a P384 public key.
     /// - Parameter publicKey: The `P384.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P384.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P384.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
     /// Returns the X9.62 compressed representation of a P521 public key.
     /// - Parameter publicKey: The `P521.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P521.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P521.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
@@ -410,7 +410,7 @@ actor CryptoHelper {
     ///   - info: Optional context/application-specific info string for HKDF.
     ///   - count: The desired output length in bytes (defaults to 32).
     /// - Returns: The derived key as `Data`.
-    public static func hkdf(salt: Data, ikm: Data, info: String?, count: Int = 32) -> Data {
+    static func hkdf(salt: Data, ikm: Data, info: String?, count: Int = 32) -> Data {
         // Convert SharedSecret (as ikm) to SymmetricKey for HKDF input
         let symmetricIkm = SymmetricKey(data: ikm)
 

--- a/OpenTDFKit/CryptoHelper.swift
+++ b/OpenTDFKit/CryptoHelper.swift
@@ -67,7 +67,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P256 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P256.KeyAgreement.PrivateKey, publicKey: P256.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P256.KeyAgreement.PrivateKey, publicKey: P256.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         // Extract raw bytes from the SharedSecret object
         return sharedSecret.withUnsafeBytes { Data($0) }
@@ -79,7 +79,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P384 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P384.KeyAgreement.PrivateKey, publicKey: P384.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P384.KeyAgreement.PrivateKey, publicKey: P384.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         return sharedSecret.withUnsafeBytes { Data($0) }
     }
@@ -90,7 +90,7 @@ actor CryptoHelper {
     ///   - publicKey: The corresponding P521 public key.
     /// - Returns: The raw shared secret as `Data`.
     /// - Throws: `CryptoKitError` if key agreement fails.
-    public static func customECDH(privateKey: P521.KeyAgreement.PrivateKey, publicKey: P521.KeyAgreement.PublicKey) throws -> Data {
+    static func customECDH(privateKey: P521.KeyAgreement.PrivateKey, publicKey: P521.KeyAgreement.PublicKey) throws -> Data {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         return sharedSecret.withUnsafeBytes { Data($0) }
     }
@@ -98,35 +98,35 @@ actor CryptoHelper {
     /// Returns the byte representation for a given KAS key curve.
     /// - Parameter curve: The `KasKeyCurve` enum value.
     /// - Returns: The `UInt8` byte value for the curve.
-    public static func kasKeyCurveByte(for curve: KasKeyCurve) -> UInt8 {
+    static func kasKeyCurveByte(for curve: KasKeyCurve) -> UInt8 {
         curve.rawValue
     }
 
     /// Returns the `KasKeyCurve` enum value for a given byte.
     /// - Parameter byte: The `UInt8` byte value representing the curve.
     /// - Returns: An optional `KasKeyCurve` if the byte corresponds to a defined curve, otherwise `nil`.
-    public static func curve(fromKasKeyCurveByte byte: UInt8) -> KasKeyCurve? {
+    static func curve(fromKasKeyCurveByte byte: UInt8) -> KasKeyCurve? {
         KasKeyCurve(rawValue: byte)
     }
 
     /// Returns the X9.62 compressed representation of a P256 public key.
     /// - Parameter publicKey: The `P256.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P256.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P256.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
     /// Returns the X9.62 compressed representation of a P384 public key.
     /// - Parameter publicKey: The `P384.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P384.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P384.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
     /// Returns the X9.62 compressed representation of a P521 public key.
     /// - Parameter publicKey: The `P521.KeyAgreement.PublicKey`.
     /// - Returns: The compressed public key as `Data`.
-    public static func getCompressedRepresentation(for publicKey: P521.KeyAgreement.PublicKey) -> Data {
+    static func getCompressedRepresentation(for publicKey: P521.KeyAgreement.PublicKey) -> Data {
         publicKey.compressedRepresentation
     }
 
@@ -144,21 +144,21 @@ actor CryptoHelper {
             return EphemeralKeyPair(
                 privateKey: privateKey.rawRepresentation,
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                curve: curveType
+                curve: curveType,
             )
         case .secp384r1:
             let privateKey = P384.KeyAgreement.PrivateKey()
             return EphemeralKeyPair(
                 privateKey: privateKey.rawRepresentation,
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                curve: curveType
+                curve: curveType,
             )
         case .secp521r1:
             let privateKey = P521.KeyAgreement.PrivateKey()
             return EphemeralKeyPair(
                 privateKey: privateKey.rawRepresentation,
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                curve: curveType
+                curve: curveType,
             )
         }
     }
@@ -199,14 +199,14 @@ actor CryptoHelper {
         sharedSecret: SharedSecret,
         salt: Data = CryptoConstants.hkdfSalt,
         info: Data = CryptoConstants.hkdfInfoEncryption,
-        outputByteCount: Int = CryptoConstants.symmetricKeyByteCount
+        outputByteCount: Int = CryptoConstants.symmetricKeyByteCount,
     ) -> SymmetricKey {
         // Use the hkdfDerivedSymmetricKey method on SharedSecret for efficient derivation.
         sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
             salt: salt,
             sharedInfo: info,
-            outputByteCount: outputByteCount
+            outputByteCount: outputByteCount,
         )
     }
 
@@ -398,7 +398,7 @@ actor CryptoHelper {
     ///   - info: Optional context/application-specific info string for HKDF.
     ///   - count: The desired output length in bytes (defaults to 32).
     /// - Returns: The derived key as `Data`.
-    public static func hkdf(salt: Data, ikm: Data, info: String?, count: Int = 32) -> Data {
+    static func hkdf(salt: Data, ikm: Data, info: String?, count: Int = 32) -> Data {
         // Convert SharedSecret (as ikm) to SymmetricKey for HKDF input
         let symmetricIkm = SymmetricKey(data: ikm)
 

--- a/OpenTDFKit/CryptoHelper.swift
+++ b/OpenTDFKit/CryptoHelper.swift
@@ -213,15 +213,17 @@ actor CryptoHelper {
     /// Creates a GMAC (Galois/Message Authentication Code) binding tag for policy data.
     /// This is achieved by performing an AES-GCM seal operation with empty plaintext
     /// and the policy data as authenticated data (AAD). The resulting tag serves as the binding.
+    /// Per NanoTDF spec section 3.3.1.3, the GMAC tag is truncated to 64 bits (8 bytes).
     /// - Parameters:
     ///   - policyBody: The policy data to bind.
     ///   - symmetricKey: The symmetric key (derived from ECDH/HKDF) to use for generating the tag.
-    /// - Returns: The calculated GMAC tag as `Data`.
+    /// - Returns: The calculated GMAC tag truncated to 8 bytes as `Data`.
     /// - Throws: `CryptoKitError` if the AES-GCM seal operation fails.
     func createGMACBinding(policyBody: Data, symmetricKey: SymmetricKey) throws -> Data {
         // Seal empty data, authenticating the policyBody. The tag is the GMAC binding.
         let sealedBox = try AES.GCM.seal(Data(), using: symmetricKey, authenticating: policyBody)
-        return sealedBox.tag
+        // Truncate to 64 bits (8 bytes) per spec section 3.3.1.3
+        return Data(sealedBox.tag.prefix(8))
     }
 
     /// Generates a cryptographically secure random nonce (IV) of the specified length.

--- a/OpenTDFKit/KeyStore.swift
+++ b/OpenTDFKit/KeyStore.swift
@@ -127,19 +127,19 @@ public actor KeyStore {
             let privateKey = P521.KeyAgreement.PrivateKey()
             return StoredKeyPair(
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                privateKey: privateKey.rawRepresentation
+                privateKey: privateKey.rawRepresentation,
             )
         case .secp384r1:
             let privateKey = P384.KeyAgreement.PrivateKey()
             return StoredKeyPair(
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                privateKey: privateKey.rawRepresentation
+                privateKey: privateKey.rawRepresentation,
             )
         case .secp256r1:
             let privateKey = P256.KeyAgreement.PrivateKey()
             return StoredKeyPair(
                 publicKey: privateKey.publicKey.compressedRepresentation,
-                privateKey: privateKey.rawRepresentation
+                privateKey: privateKey.rawRepresentation,
             )
         }
     }
@@ -208,7 +208,7 @@ public actor KeyStore {
 
             let keyPair = StoredKeyPair(
                 publicKey: Data(publicKey),
-                privateKey: Data(privateKey)
+                privateKey: Data(privateKey),
             )
 
             let identifier = KeyPairIdentifier(publicKey: keyPair.publicKey)
@@ -244,7 +244,7 @@ public actor KeyStore {
     /// - Throws: KeyStoreError or other errors if key derivation fails.
     public func derivePayloadSymmetricKey(
         kasPublicKey: Data,
-        tdfEphemeralPublicKey: Data
+        tdfEphemeralPublicKey: Data,
     ) async throws -> SymmetricKey {
         // 1. Get the KAS's private key from this KeyStore
         // The kasPublicKeyForLookup is the KAS's own public key, used to identify its private key.
@@ -281,7 +281,7 @@ public actor KeyStore {
             using: SHA256.self,
             salt: Data("L1M".utf8), // v13 salt
             sharedInfo: Data("encryption".utf8), // Standard info for payload encryption
-            outputByteCount: 32 // For AES-256
+            outputByteCount: 32, // For AES-256
         )
 
         return symmetricKeyCryptoKit

--- a/OpenTDFKit/KeyStore.swift
+++ b/OpenTDFKit/KeyStore.swift
@@ -274,14 +274,14 @@ public actor KeyStore {
         }
 
         // 3. Derive the symmetric key using HKDF (v13 specific)
-        //    Salt: "L1M" for v13
-        //    Info: "encryption" for payload symmetric key
+        //    Salt: SHA256("L1" + VERSION)
+        //    Info: empty per spec guidance
         //    Output Byte Count: 32 (for AES-256)
         let symmetricKeyCryptoKit = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8), // v13 salt
-            sharedInfo: Data("encryption".utf8), // Standard info for payload encryption
-            outputByteCount: 32, // For AES-256
+            salt: CryptoConstants.hkdfSaltV13,
+            sharedInfo: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
 
         return symmetricKeyCryptoKit

--- a/OpenTDFKit/NanoTDF.swift
+++ b/OpenTDFKit/NanoTDF.swift
@@ -1,15 +1,6 @@
 @preconcurrency import CryptoKit
 import Foundation
 
-/// Computes the HKDF salt according to NanoTDF spec section 4.
-/// The salt is SHA256(MAGIC_NUMBER + VERSION).
-/// - Parameter version: The NanoTDF version byte (0x4C for v12, 0x4D for v13)
-/// - Returns: The computed salt as Data
-private func computeHKDFSalt(version: UInt8) -> Data {
-    let magicAndVersion = Header.magicNumber + Data([version])
-    return Data(SHA256.hash(data: magicAndVersion))
-}
-
 /// Represents a NanoTDF (Nano Trusted Data Format) object, containing a header, payload, and optional signature.
 /// Conforms to `Sendable` for safe use in concurrent contexts.
 public struct NanoTDF: Sendable {
@@ -103,7 +94,7 @@ public func createNanoTDF(kas: KasMetadata, policy: inout Policy, plaintext: Dat
 
     // Step 3: Derive the symmetric TDF key from the shared secret using HKDF
     // Salt is SHA256(MAGIC_NUMBER + VERSION) per spec section 4
-    let salt = computeHKDFSalt(version: Header.version) // v13 by default
+    let salt = CryptoHelper.computeHKDFSalt(version: Header.version) // v13 by default
     let tdfSymmetricKey = await cryptoHelper.deriveSymmetricKey(
         sharedSecret: sharedSecret,
         salt: salt,

--- a/OpenTDFKitTests/CryptoHelperTests.swift
+++ b/OpenTDFKitTests/CryptoHelperTests.swift
@@ -33,6 +33,7 @@ final class CryptoHelperTests: XCTestCase {
 
         // Step 4: Verify the results
         XCTAssertNotNil(result.gmacTag, "GMAC tag should not be nil")
+        XCTAssertEqual(result.gmacTag.count, 8, "GMAC tag should be truncated to 8 bytes (64 bits)")
         XCTAssertNotNil(result.ciphertext, "Ciphertext should not be nil")
         XCTAssertNotNil(result.tag, "Authentication tag should not be nil")
         XCTAssertNotNil(result.nonce, "Nonce should not be nil")
@@ -81,9 +82,9 @@ extension CryptoHelper {
         // Derive symmetric key
         let symmetricKey = deriveSymmetricKey(
             sharedSecret: sharedSecret,
-            salt: Data("L1M".utf8), // Updated to v13 salt
-            info: Data("encryption".utf8),
-            outputByteCount: 32,
+            salt: CryptoConstants.hkdfSalt,
+            info: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
 
         // Create GMAC binding
@@ -128,9 +129,9 @@ extension CryptoHelper {
         // Derive symmetric key
         let symmetricKey = deriveSymmetricKey(
             sharedSecret: sharedSecret,
-            salt: Data("L1M".utf8), // Updated to v13 salt
-            info: Data("encryption".utf8),
-            outputByteCount: 32,
+            salt: CryptoConstants.hkdfSalt,
+            info: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
 
         // Decrypt

--- a/OpenTDFKitTests/CryptoHelperTests.swift
+++ b/OpenTDFKitTests/CryptoHelperTests.swift
@@ -28,7 +28,7 @@ final class CryptoHelperTests: XCTestCase {
             keyPair: keyPair,
             recipientPublicKey: recipientDER,
             plaintext: "This is a secret message".data(using: .utf8)!,
-            policyBody: "classification:secret".data(using: .utf8)!
+            policyBody: "classification:secret".data(using: .utf8)!,
         )
 
         // Step 4: Verify the results
@@ -43,13 +43,13 @@ final class CryptoHelperTests: XCTestCase {
             recipientPublicKey: recipientDER,
             ciphertext: result.ciphertext,
             nonce: result.nonce,
-            tag: result.tag
+            tag: result.tag,
         )
 
         XCTAssertEqual(
             String(data: decrypted, encoding: .utf8),
             "This is a secret message",
-            "Decrypted text should match original plaintext"
+            "Decrypted text should match original plaintext",
         )
     }
 }
@@ -68,12 +68,12 @@ extension CryptoHelper {
         keyPair: EphemeralKeyPair,
         recipientPublicKey: Data,
         plaintext: Data,
-        policyBody: Data
+        policyBody: Data,
     ) throws -> EncryptionResult {
         // Derive shared secret
         guard let sharedSecret = try deriveSharedSecret(
             keyPair: keyPair,
-            recipientPublicKey: recipientPublicKey
+            recipientPublicKey: recipientPublicKey,
         ) else {
             throw CryptoHelperError.keyDerivationFailed
         }
@@ -83,13 +83,13 @@ extension CryptoHelper {
             sharedSecret: sharedSecret,
             salt: Data("L1M".utf8), // Updated to v13 salt
             info: Data("encryption".utf8),
-            outputByteCount: 32
+            outputByteCount: 32,
         )
 
         // Create GMAC binding
         let gmacTag = try createGMACBinding(
             policyBody: policyBody,
-            symmetricKey: symmetricKey
+            symmetricKey: symmetricKey,
         )
 
         // Generate nonce
@@ -99,14 +99,14 @@ extension CryptoHelper {
         let (ciphertext, tag) = try encryptPayload(
             plaintext: plaintext,
             symmetricKey: symmetricKey,
-            nonce: nonce
+            nonce: nonce,
         )
 
         return EncryptionResult(
             gmacTag: gmacTag,
             nonce: nonce,
             ciphertext: ciphertext,
-            tag: tag
+            tag: tag,
         )
     }
 
@@ -115,12 +115,12 @@ extension CryptoHelper {
         recipientPublicKey: Data,
         ciphertext: Data,
         nonce: Data,
-        tag: Data
+        tag: Data,
     ) throws -> Data {
         // Derive shared secret
         guard let sharedSecret = try deriveSharedSecret(
             keyPair: keyPair,
-            recipientPublicKey: recipientPublicKey
+            recipientPublicKey: recipientPublicKey,
         ) else {
             throw CryptoHelperError.keyDerivationFailed
         }
@@ -130,7 +130,7 @@ extension CryptoHelper {
             sharedSecret: sharedSecret,
             salt: Data("L1M".utf8), // Updated to v13 salt
             info: Data("encryption".utf8),
-            outputByteCount: 32
+            outputByteCount: 32,
         )
 
         // Decrypt
@@ -138,7 +138,7 @@ extension CryptoHelper {
             ciphertext: ciphertext,
             symmetricKey: symmetricKey,
             nonce: nonce,
-            tag: tag
+            tag: tag,
         )
     }
 }

--- a/OpenTDFKitTests/EncryptedPolicyTests.swift
+++ b/OpenTDFKitTests/EncryptedPolicyTests.swift
@@ -75,22 +75,14 @@ final class EncryptedPolicyTests: XCTestCase {
         XCTAssertEqual(serializedData, reserializedData, "Serialized data should match after round-trip")
     }
 
-    // TODO: Fix encrypted policy test when the required infrastructure is in place
-    // Requires working with KeyStore and proper policy KAS setup
-    func disabled_testEncryptedPolicyWithKeyAccess() async throws {
-        // Create KAS ResourceLocator
+    // Test encrypted policy with key access using the same KAS for both payload and policy
+    func testEncryptedPolicyWithKeyAccess() async throws {
+        // Create KAS ResourceLocator (same KAS for both payload and policy)
         let kasRL = ResourceLocator(protocolEnum: .http, body: "kas.example.org")!
-
-        // Create Policy KAS ResourceLocator (could be the same or different from main KAS)
-        let policyKasRL = ResourceLocator(protocolEnum: .http, body: "policy-kas.example.org")!
 
         // Generate a key pair for the KAS
         let kasKeyPair = P256.KeyAgreement.PrivateKey()
         let kasPubKey = kasKeyPair.publicKey
-
-        // Generate a key pair for the policy KAS
-        let policyKasKeyPair = P256.KeyAgreement.PrivateKey()
-        let policyKasPubKey = policyKasKeyPair.publicKey
 
         // Create KAS metadata
         let kasMetadata = try KasMetadata(resourceLocator: kasRL, publicKey: kasPubKey, curve: .secp256r1)
@@ -104,10 +96,13 @@ final class EncryptedPolicyTests: XCTestCase {
         }
         """.data(using: .utf8)!
 
-        // Create PolicyKeyAccess with policy KAS information
+        // Create PolicyKeyAccess with a dummy ephemeral key (will be replaced during encryption)
+        // The ephemeralPublicKey here is just a placeholder - it will be replaced with the
+        // newly generated ephemeral key during policy encryption
+        let dummyEphemeralKey = P256.KeyAgreement.PrivateKey().publicKey.compressedRepresentation
         let policyKeyAccess = PolicyKeyAccess(
-            resourceLocator: policyKasRL,
-            ephemeralPublicKey: policyKasPubKey.compressedRepresentation
+            resourceLocator: kasRL, // Same KAS as for payload
+            ephemeralPublicKey: dummyEphemeralKey
         )
 
         // Create EmbeddedPolicyBody with plaintext policy and key access

--- a/OpenTDFKitTests/EncryptedPolicyTests.swift
+++ b/OpenTDFKitTests/EncryptedPolicyTests.swift
@@ -26,7 +26,7 @@ final class EncryptedPolicyTests: XCTestCase {
         // Create EmbeddedPolicyBody with plaintext policy
         let embeddedPolicyBody = EmbeddedPolicyBody(
             body: policyData,
-            keyAccess: nil
+            keyAccess: nil,
         )
 
         // Create Policy with embeddedEncryptedWithPolicyKeyAccess type
@@ -34,7 +34,7 @@ final class EncryptedPolicyTests: XCTestCase {
             type: .embeddedPlaintext,
             body: embeddedPolicyBody,
             remote: nil,
-            binding: nil
+            binding: nil,
         )
 
         // Create plaintext payload
@@ -102,13 +102,13 @@ final class EncryptedPolicyTests: XCTestCase {
         let dummyEphemeralKey = P256.KeyAgreement.PrivateKey().publicKey.compressedRepresentation
         let policyKeyAccess = PolicyKeyAccess(
             resourceLocator: kasRL, // Same KAS as for payload
-            ephemeralPublicKey: dummyEphemeralKey
+            ephemeralPublicKey: dummyEphemeralKey,
         )
 
         // Create EmbeddedPolicyBody with plaintext policy and key access
         let embeddedPolicyBody = EmbeddedPolicyBody(
             body: policyData,
-            keyAccess: policyKeyAccess
+            keyAccess: policyKeyAccess,
         )
 
         // Create Policy with embeddedEncryptedWithPolicyKeyAccess type
@@ -116,7 +116,7 @@ final class EncryptedPolicyTests: XCTestCase {
             type: .embeddedEncryptedWithPolicyKeyAccess,
             body: embeddedPolicyBody,
             remote: nil,
-            binding: nil
+            binding: nil,
         )
 
         // Create plaintext payload

--- a/OpenTDFKitTests/InitializationTests.swift
+++ b/OpenTDFKitTests/InitializationTests.swift
@@ -11,7 +11,7 @@ func initializeSmallNanoTDF(kasResourceLocator: ResourceLocator) -> NanoTDF {
     // Create a PayloadKeyAccess structure with the KAS ResourceLocator
     let payloadKeyAccess = PayloadKeyAccess(
         kasEndpointLocator: kasResourceLocator,
-        kasPublicKey: Data([0x02, 0x03, 0x04]) // Placeholder compressed public key
+        kasPublicKey: Data([0x02, 0x03, 0x04]), // Placeholder compressed public key
     )
 
     // Create a placeholder header
@@ -20,7 +20,7 @@ func initializeSmallNanoTDF(kasResourceLocator: ResourceLocator) -> NanoTDF {
         policyBindingConfig: PolicyBindingConfig(ecdsaBinding: false, curve: curve), // GMAC binding
         payloadSignatureConfig: SignatureAndPayloadConfig(signed: false, signatureCurve: curve, payloadCipher: .aes256GCM128), // Not signed, AES-256-GCM-128
         policy: Policy(type: .remote, body: nil, remote: kasResourceLocator, binding: nil), // Remote policy pointing to KAS URL, no binding yet
-        ephemeralPublicKey: Data([0x04, 0x05, 0x06]) // Placeholder ephemeral public key
+        ephemeralPublicKey: Data([0x04, 0x05, 0x06]), // Placeholder ephemeral public key
     )
 
     // Create a placeholder payload
@@ -28,7 +28,7 @@ func initializeSmallNanoTDF(kasResourceLocator: ResourceLocator) -> NanoTDF {
         length: 7, // Minimal length (3 IV + 1 Ciphertext + 3 Placeholder MAC)
         iv: Data([0x07, 0x08, 0x09]), // Placeholder IV
         ciphertext: Data([0x00]), // Placeholder ciphertext
-        mac: Data([0x13, 0x14, 0x15]) // Placeholder MAC tag (incorrect size for AES-GCM-128)
+        mac: Data([0x13, 0x14, 0x15]), // Placeholder MAC tag (incorrect size for AES-GCM-128)
     )
 
     // Return the NanoTDF object
@@ -79,7 +79,7 @@ final class InitializationTests: XCTestCase {
             policyBindingConfig: PolicyBindingConfig(ecdsaBinding: false, curve: .secp256r1),
             payloadSignatureConfig: SignatureAndPayloadConfig(signed: false, signatureCurve: nil, payloadCipher: .aes256GCM128),
             policy: Policy(type: .embeddedPlaintext, body: nil, remote: nil, binding: nil),
-            ephemeralPublicKey: Data([0x04, 0x05, 0x06])
+            ephemeralPublicKey: Data([0x04, 0x05, 0x06]),
         ))
     }
 

--- a/OpenTDFKitTests/KASServiceBenchmarkTests.swift
+++ b/OpenTDFKitTests/KASServiceBenchmarkTests.swift
@@ -14,7 +14,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
         let iterations = 100
 
         for _ in 0 ..< iterations {
-            let _ = try await kasService.generateKasMetadata()
+            _ = try await kasService.generateKasMetadata()
         }
 
         let endTime = DispatchTime.now()
@@ -69,7 +69,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
                 // Create a shared secret for encryption
                 guard let sharedSecret = try await cryptoHelper.deriveSharedSecret(
                     keyPair: ephemeralKeyPair,
-                    recipientPublicKey: kasPublicKey
+                    recipientPublicKey: kasPublicKey,
                 ) else {
                     continue
                 }
@@ -78,7 +78,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
                 let symmetricKey = await cryptoHelper.deriveSymmetricKey(
                     sharedSecret: sharedSecret,
                     salt: Data("test".utf8),
-                    info: Data("benchmark".utf8)
+                    info: Data("benchmark".utf8),
                 )
 
                 // Encrypt sample data with proper format
@@ -94,10 +94,10 @@ final class KASServiceBenchmarkTests: XCTestCase {
 
                 // Process key access (the actual benchmark operation)
                 do {
-                    let _ = try await kasService.processKeyAccess(
+                    _ = try await kasService.processKeyAccess(
                         ephemeralPublicKey: ephemeralKeyPair.publicKey,
                         encryptedKey: encryptedKey,
-                        kasPublicKey: kasPublicKey
+                        kasPublicKey: kasPublicKey,
                     )
                 } catch {
                     print("Error processing key access: \(error)")
@@ -116,7 +116,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
     func testPolicyBindingVerificationPerformance() async throws {
         let kasService = KASService(
             keyStore: KeyStore(curve: .secp256r1, capacity: 10),
-            baseURL: URL(string: "https://example.kas.com")!
+            baseURL: URL(string: "https://example.kas.com")!,
         )
 
         // Generate test data
@@ -136,10 +136,10 @@ final class KASServiceBenchmarkTests: XCTestCase {
             let startTime = DispatchTime.now()
 
             for _ in 0 ..< iterations {
-                let _ = try await kasService.verifyPolicyBinding(
+                _ = try await kasService.verifyPolicyBinding(
                     policyBinding: policyBinding,
                     policyData: policyData,
-                    symmetricKey: symmetricKey
+                    symmetricKey: symmetricKey,
                 )
             }
 
@@ -179,7 +179,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
             let metadataStartTime = DispatchTime.now()
 
             for _ in 0 ..< iterations {
-                let _ = try await kasService.generateKasMetadata()
+                _ = try await kasService.generateKasMetadata()
             }
 
             let metadataEndTime = DispatchTime.now()
@@ -201,10 +201,10 @@ final class KASServiceBenchmarkTests: XCTestCase {
                 let encryptedKey = Data(repeating: 0xAA, count: 64)
 
                 do {
-                    let _ = try await kasService.processKeyAccess(
+                    _ = try await kasService.processKeyAccess(
                         ephemeralPublicKey: ephemeralKeyPair.publicKey,
                         encryptedKey: encryptedKey,
-                        kasPublicKey: kasPublicKey
+                        kasPublicKey: kasPublicKey,
                     )
                 } catch {
                     // Expected to fail with invalid format, we're just measuring performance

--- a/OpenTDFKitTests/KASServiceBenchmarkTests.swift
+++ b/OpenTDFKitTests/KASServiceBenchmarkTests.swift
@@ -77,8 +77,8 @@ final class KASServiceBenchmarkTests: XCTestCase {
                 // Derive a symmetric key
                 let symmetricKey = await cryptoHelper.deriveSymmetricKey(
                     sharedSecret: sharedSecret,
-                    salt: Data("test".utf8),
-                    info: Data("benchmark".utf8),
+                    salt: CryptoConstants.hkdfSalt,
+                    info: CryptoConstants.hkdfInfoEncryption,
                 )
 
                 // Encrypt sample data with proper format

--- a/OpenTDFKitTests/KASServiceTests.swift
+++ b/OpenTDFKitTests/KASServiceTests.swift
@@ -63,8 +63,7 @@ final class KASServiceTests: XCTestCase {
 
         // Derive symmetric key using the same parameters as in createNanoTDF
         // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
-        let magicAndVersion = Header.magicNumber + Data([Header.version])
-        let salt = Data(SHA256.hash(data: magicAndVersion))
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
 
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
@@ -146,8 +145,7 @@ final class KASServiceTests: XCTestCase {
         let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: ephemeralPublicKey)
 
         // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
-        let magicAndVersion = Header.magicNumber + Data([Header.version])
-        let salt = Data(SHA256.hash(data: magicAndVersion))
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
 
         // Derive the same shared secret that would be used in the TDF creation
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
@@ -215,8 +213,9 @@ final class KASServiceTests: XCTestCase {
          )
 
          // Extract the policy binding from the created NanoTDF
-         let policyBinding = nanoTDF.header.policy.binding
-         XCTAssertNotNil(policyBinding, "Policy binding should be created during NanoTDF creation")
+        let policyBinding = nanoTDF.header.policy.binding
+        XCTAssertNotNil(policyBinding, "Policy binding should be created during NanoTDF creation")
+        XCTAssertEqual(policyBinding?.count, 8, "Policy binding should be 8 bytes (64 bits)")
 
          // Get the KAS public key and derive the same symmetric key that was used for binding
          let kasPublicKey = try kasMetadata.getPublicKey()
@@ -230,8 +229,7 @@ final class KASServiceTests: XCTestCase {
 
          // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
          // Using v13 (L1M) since createNanoTDF uses v13 by default
-         let magicAndVersion = Header.magicNumber + Data([Header.version])
-         let salt = Data(SHA256.hash(data: magicAndVersion))
+         let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
 
          let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
              using: SHA256.self,

--- a/OpenTDFKitTests/KASServiceTests.swift
+++ b/OpenTDFKitTests/KASServiceTests.swift
@@ -62,10 +62,14 @@ final class KASServiceTests: XCTestCase {
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
 
         // Derive symmetric key using the same parameters as in createNanoTDF
+        // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
+        let magicAndVersion = Header.magicNumber + Data([Header.version])
+        let salt = Data(SHA256.hash(data: magicAndVersion))
+
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8), // Use v13 salt
-            sharedInfo: Data("encryption".utf8),
+            salt: salt,
+            sharedInfo: Data(), // Empty per spec section 4
             outputByteCount: 32
         )
 
@@ -141,12 +145,16 @@ final class KASServiceTests: XCTestCase {
         let privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateKeyData!)
         let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: ephemeralPublicKey)
 
+        // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
+        let magicAndVersion = Header.magicNumber + Data([Header.version])
+        let salt = Data(SHA256.hash(data: magicAndVersion))
+
         // Derive the same shared secret that would be used in the TDF creation
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
         let derivedSymmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8), // Use v13 salt
-            sharedInfo: Data("encryption".utf8),
+            salt: salt,
+            sharedInfo: Data(), // Empty per spec section 4
             outputByteCount: 32
         )
 
@@ -220,10 +228,15 @@ final class KASServiceTests: XCTestCase {
          let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: nanoTDF.header.ephemeralPublicKey)
          let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
 
+         // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
+         // Using v13 (L1M) since createNanoTDF uses v13 by default
+         let magicAndVersion = Header.magicNumber + Data([Header.version])
+         let salt = Data(SHA256.hash(data: magicAndVersion))
+
          let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
              using: SHA256.self,
-             salt: Data("L1L".utf8),
-             sharedInfo: Data("encryption".utf8),
+             salt: salt,
+             sharedInfo: Data(), // Empty per spec section 4
              outputByteCount: 32
          )
 

--- a/OpenTDFKitTests/KASServiceTests.swift
+++ b/OpenTDFKitTests/KASServiceTests.swift
@@ -33,7 +33,7 @@ final class KASServiceTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: originalPlaintext
+            plaintext: originalPlaintext,
         )
 
         // Verify the NanoTDF was created successfully
@@ -70,7 +70,7 @@ final class KASServiceTests: XCTestCase {
             using: SHA256.self,
             salt: salt,
             sharedInfo: Data(), // Empty per spec section 4
-            outputByteCount: 32
+            outputByteCount: 32,
         )
 
         // 10. Decrypt the NanoTDF payload
@@ -125,7 +125,7 @@ final class KASServiceTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: plaintext
+            plaintext: plaintext,
         )
         XCTAssertEqual(nanoTDF.header.toData()[2], Header.version, "NanoTDF header should be v13")
 
@@ -155,7 +155,7 @@ final class KASServiceTests: XCTestCase {
             using: SHA256.self,
             salt: salt,
             sharedInfo: Data(), // Empty per spec section 4
-            outputByteCount: 32
+            outputByteCount: 32,
         )
 
         // Encrypt the session key with the derived symmetric key
@@ -174,7 +174,7 @@ final class KASServiceTests: XCTestCase {
         let rewrappedKey = try await kasService.processKeyAccess(
             ephemeralPublicKey: ephemeralPublicKey,
             encryptedKey: encryptedKey,
-            kasPublicKey: kasPublicKey
+            kasPublicKey: kasPublicKey,
         )
 
         // Verify the rewrapped key is not empty

--- a/OpenTDFKitTests/KeyStoreTests.swift
+++ b/OpenTDFKitTests/KeyStoreTests.swift
@@ -136,9 +136,9 @@ final class KeyStoreTests: XCTestCase {
         let sharedSecret = try kasPrivKey.sharedSecretFromKeyAgreement(with: clientPubKey)
         let expectedSymKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8),
-            sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32,
+            salt: CryptoConstants.hkdfSaltV13,
+            sharedInfo: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }
@@ -172,9 +172,9 @@ final class KeyStoreTests: XCTestCase {
         let sharedSecret = try kasPrivKey.sharedSecretFromKeyAgreement(with: clientPubKey)
         let expectedSymKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8),
-            sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32,
+            salt: CryptoConstants.hkdfSaltV13,
+            sharedInfo: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }
@@ -208,9 +208,9 @@ final class KeyStoreTests: XCTestCase {
         let sharedSecret = try kasPrivKey.sharedSecretFromKeyAgreement(with: clientPubKey)
         let expectedSymKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1M".utf8),
-            sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32,
+            salt: CryptoConstants.hkdfSaltV13,
+            sharedInfo: CryptoConstants.hkdfInfoEncryption,
+            outputByteCount: CryptoConstants.symmetricKeyByteCount,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }

--- a/OpenTDFKitTests/KeyStoreTests.swift
+++ b/OpenTDFKitTests/KeyStoreTests.swift
@@ -123,7 +123,7 @@ final class KeyStoreTests: XCTestCase {
         // Action
         let derivedSymKey = try await keyStore.derivePayloadSymmetricKey(
             kasPublicKey: kasStoredKeyPair.publicKey,
-            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey
+            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey,
         )
 
         // Assertions
@@ -138,7 +138,7 @@ final class KeyStoreTests: XCTestCase {
             using: SHA256.self,
             salt: Data("L1M".utf8),
             sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32
+            outputByteCount: 32,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }
@@ -160,7 +160,7 @@ final class KeyStoreTests: XCTestCase {
         // Action
         let derivedSymKey = try await keyStore.derivePayloadSymmetricKey(
             kasPublicKey: kasStoredKeyPair.publicKey,
-            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey
+            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey,
         )
 
         // Assertions
@@ -174,7 +174,7 @@ final class KeyStoreTests: XCTestCase {
             using: SHA256.self,
             salt: Data("L1M".utf8),
             sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32
+            outputByteCount: 32,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }
@@ -196,7 +196,7 @@ final class KeyStoreTests: XCTestCase {
         // Action
         let derivedSymKey = try await keyStore.derivePayloadSymmetricKey(
             kasPublicKey: kasStoredKeyPair.publicKey,
-            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey
+            tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey,
         )
 
         // Assertions
@@ -210,7 +210,7 @@ final class KeyStoreTests: XCTestCase {
             using: SHA256.self,
             salt: Data("L1M".utf8),
             sharedInfo: Data("encryption".utf8),
-            outputByteCount: 32
+            outputByteCount: 32,
         )
         // Convert both to data for comparison
         let derivedSymKeyData = derivedSymKey.withUnsafeBytes { Data($0) }
@@ -236,7 +236,7 @@ final class KeyStoreTests: XCTestCase {
         do {
             _ = try await keyStore.derivePayloadSymmetricKey(
                 kasPublicKey: kasPublicKeyNotInStore,
-                tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey
+                tdfEphemeralPublicKey: clientEphemeralKeyPair.publicKey,
             )
             XCTFail("Should have thrown KeyStoreError.keyNotFound")
         } catch {

--- a/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
+++ b/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
@@ -226,8 +226,8 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         // 2. Derive symmetric key
         let symmetricKey = await cryptoHelper.deriveSymmetricKey(
             sharedSecret: sharedSecret,
-            salt: Data("L1L".utf8),
-            info: Data("encryption".utf8),
+            salt: CryptoConstants.hkdfSalt,
+            info: CryptoConstants.hkdfInfoEncryption,
         )
 
         // 3. Create policy binding

--- a/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
+++ b/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
@@ -112,20 +112,20 @@ final class NanoTDFBenchmarkTests: XCTestCase {
                 // Simple encryption with symmetric key derivation
                 let sharedSecret = try await cryptoHelper.deriveSharedSecret(
                     keyPair: keyPair,
-                    recipientPublicKey: recipientKeyPair.publicKey
+                    recipientPublicKey: recipientKeyPair.publicKey,
                 )!
 
                 let symmetricKey = await cryptoHelper.deriveSymmetricKey(
                     sharedSecret: sharedSecret,
                     salt: Data("test".utf8),
-                    info: Data("benchmark".utf8)
+                    info: Data("benchmark".utf8),
                 )
 
                 let nonce = await cryptoHelper.generateNonce()
-                let _ = try await cryptoHelper.encryptPayload(
+                _ = try await cryptoHelper.encryptPayload(
                     plaintext: plaintext,
                     symmetricKey: symmetricKey,
-                    nonce: nonce
+                    nonce: nonce,
                 )
             }
 
@@ -146,7 +146,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let (ciphertext, tag) = try await cryptoHelper.encryptPayload(
             plaintext: plaintext,
             symmetricKey: symmetricKey,
-            nonce: nonce
+            nonce: nonce,
         )
 
         // Measure manually instead of using XCTest measure
@@ -154,11 +154,11 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let startTime = DispatchTime.now()
 
         for _ in 0 ..< iterations {
-            let _ = try await cryptoHelper.decryptPayload(
+            _ = try await cryptoHelper.decryptPayload(
                 ciphertext: ciphertext,
                 symmetricKey: symmetricKey,
                 nonce: nonce,
-                tag: tag
+                tag: tag,
             )
         }
 
@@ -196,7 +196,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
             let iterations = 100
 
             for _ in 0 ..< iterations {
-                let _ = tdf.toData()
+                _ = tdf.toData()
             }
 
             let endTime = DispatchTime.now()
@@ -213,12 +213,12 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         keyPair: EphemeralKeyPair,
         recipientPublicKey: Data,
         plaintext: Data,
-        policyBody: Data
+        policyBody: Data,
     ) async throws -> (encryptedData: Data, policyBinding: Data) {
         // 1. Derive shared secret
         guard let sharedSecret = try await cryptoHelper.deriveSharedSecret(
             keyPair: keyPair,
-            recipientPublicKey: recipientPublicKey
+            recipientPublicKey: recipientPublicKey,
         ) else {
             throw CryptoHelperError.keyDerivationFailed
         }
@@ -227,7 +227,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let symmetricKey = await cryptoHelper.deriveSymmetricKey(
             sharedSecret: sharedSecret,
             salt: Data("L1L".utf8),
-            info: Data("encryption".utf8)
+            info: Data("encryption".utf8),
         )
 
         // 3. Create policy binding
@@ -238,7 +238,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let (ciphertext, tag) = try await cryptoHelper.encryptPayload(
             plaintext: plaintext,
             symmetricKey: symmetricKey,
-            nonce: nonce
+            nonce: nonce,
         )
 
         // 5. Combine encrypted components
@@ -270,7 +270,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
                     keyPair: keyPair,
                     recipientPublicKey: recipientDER,
                     plaintext: plaintext,
-                    policyBody: policyBody
+                    policyBody: policyBody,
                 )
                 expectation.fulfill()
             }

--- a/OpenTDFKitTests/NanoTDFTests.swift
+++ b/OpenTDFKitTests/NanoTDFTests.swift
@@ -563,20 +563,28 @@ final class NanoTDFTests: XCTestCase {
         let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: nanoTDF.header.ephemeralPublicKey)
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
 
+        // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
+        // Using v12 (L1L) for this test
+        let magicAndVersion = Header.magicNumber + Data([Header.versionV12])
+        let salt = Data(SHA256.hash(data: magicAndVersion))
+
         // Convert the shared secret to a symmetric key
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: Data("L1L".utf8),
-            sharedInfo: Data("encryption".utf8),
+            salt: salt,
+            sharedInfo: Data(), // Empty per spec section 4
             outputByteCount: 32
         )
 
         // Create GMAC tag for verification - do it locally instead of using the actor method
-        let expectedTag = try AES.GCM.seal(Data(), using: symmetricKey, authenticating: policyData).tag
+        let fullTag = try AES.GCM.seal(Data(), using: symmetricKey, authenticating: policyData).tag
+        // Per spec, GMAC binding should be truncated to 8 bytes (64 bits)
+        let expectedTag = Data(fullTag.prefix(8))
 
         // Just verify that the binding is not empty - we can't predict the exact value
-        // in a test but we can make sure it was generated with a valid size
-        XCTAssertEqual(policyBinding!.count, expectedTag.count, "Policy binding should have the same length as a GMAC tag")
+        // in a test but we can make sure it was generated with a valid size (8 bytes per spec)
+        XCTAssertEqual(policyBinding!.count, 8, "Policy binding should be 8 bytes (64 bits) per spec")
+        XCTAssertEqual(policyBinding!.count, expectedTag.count, "Policy binding should have the same length as truncated GMAC tag")
 
         // Test with invalid binding
         let invalidBinding = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])

--- a/OpenTDFKitTests/NanoTDFTests.swift
+++ b/OpenTDFKitTests/NanoTDFTests.swift
@@ -565,8 +565,7 @@ final class NanoTDFTests: XCTestCase {
 
         // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
         // Using v12 (L1L) for this test
-        let magicAndVersion = Header.magicNumber + Data([Header.versionV12])
-        let salt = Data(SHA256.hash(data: magicAndVersion))
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
 
         // Convert the shared secret to a symmetric key
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(

--- a/OpenTDFKitTests/NanoTDFTests.swift
+++ b/OpenTDFKitTests/NanoTDFTests.swift
@@ -189,7 +189,7 @@ final class NanoTDFTests: XCTestCase {
             _ = SymmetricKey(size: .bits256)
 
             // Combine the IV-nonce, ciphertext, and MAC-tag
-            let _ = payload.iv + payload.ciphertext + payload.mac
+            _ = payload.iv + payload.ciphertext + payload.mac
 
             // Decrypt the payload
 //            let sealedBox = try AES.GCM.SealedBox(combined: combinedData)
@@ -415,7 +415,7 @@ final class NanoTDFTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: plaintext
+            plaintext: plaintext,
         )
 
         // Verify the NanoTDF was created properly
@@ -460,7 +460,7 @@ final class NanoTDFTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: plaintext
+            plaintext: plaintext,
         )
 
         // Verify the NanoTDF was created properly
@@ -502,7 +502,7 @@ final class NanoTDFTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: plaintext
+            plaintext: plaintext,
         )
 
         // Verify the NanoTDF was created properly
@@ -544,7 +544,7 @@ final class NanoTDFTests: XCTestCase {
         let nanoTDF = try await createNanoTDF(
             kas: kasMetadata,
             policy: &policy,
-            plaintext: plaintext
+            plaintext: plaintext,
         )
 
         // Extract the policy binding from the created NanoTDF
@@ -573,7 +573,7 @@ final class NanoTDFTests: XCTestCase {
             using: SHA256.self,
             salt: salt,
             sharedInfo: Data(), // Empty per spec section 4
-            outputByteCount: 32
+            outputByteCount: 32,
         )
 
         // Create GMAC tag for verification - do it locally instead of using the actor method

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     products: [
         .library(
             name: "OpenTDFKit",
-            targets: ["OpenTDFKit"]
+            targets: ["OpenTDFKit"],
         ),
         .executable(
             name: "OpenTDFKitProfiler",
-            targets: ["OpenTDFKitProfiler"]
+            targets: ["OpenTDFKitProfiler"],
         ),
     ],
     dependencies: [],
@@ -24,17 +24,17 @@ let package = Package(
         .target(
             name: "OpenTDFKit",
             dependencies: [],
-            path: "OpenTDFKit"
+            path: "OpenTDFKit",
         ),
         .executableTarget(
             name: "OpenTDFKitProfiler",
             dependencies: ["OpenTDFKit"],
-            path: "OpenTDFKitProfiler"
+            path: "OpenTDFKitProfiler",
         ),
         .testTarget(
             name: "OpenTDFKitTests",
             dependencies: ["OpenTDFKit"],
-            path: "OpenTDFKitTests"
+            path: "OpenTDFKitTests",
         ),
-    ]
+    ],
 )

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ sequenceDiagram
 ### Format
 
 ```shell
-swiftformat --swiftversion 6.0 .
+swiftformat --swiftversion 6.2 .
 ```
 
 ### Profile
@@ -179,5 +179,4 @@ Below are the benchmark results showing the performance characteristics of the m
 | Policy binding verification | ~0.002ms (500,000+ verifications/sec) |
 
 These benchmarks were measured on an Apple M1 Max processor using Swift 6.0 in release mode.
-
 


### PR DESCRIPTION
## Summary

This PR addresses critical security vulnerabilities and specification compliance issues identified in the code review:

- ✅ Fixed Policy KAS key handling (was using ephemeral key instead of actual KAS key)
- ✅ Corrected HKDF salt computation per NanoTDF spec section 4
- ✅ Fixed HKDF info parameter (now empty per spec)
- ✅ Truncated GMAC binding to 8 bytes per spec section 3.3.1.3

## Key Changes

### 1. Policy KAS Key Handling
**Issue**: Line 138 incorrectly used `keyAccess.ephemeralPublicKey` as the Policy KAS public key
**Fix**: Now correctly uses the actual KAS public key for ECDH

### 2. HKDF Salt (Spec Section 4)
**Before**: `Data("L1M".utf8)`
**After**: `SHA256(MAGIC_NUMBER + VERSION)`
- v12: `3de3ca1e50cf62d8b6aba603a96fca6761387a7ac86c3d3afe85ae2d1812edfc`
- v13: `5878b49e2a825498d8e6570cb87b588c67a0052c6f5280e24edd89d91ae62fbb`

### 3. HKDF Info Parameter
**Before**: `Data("encryption".utf8)`
**After**: `Data()` (empty per spec)

### 4. GMAC Binding Size
**Before**: 16 bytes (full AES-GCM tag)
**After**: 8 bytes (64 bits per spec section 3.3.1.3)

## Testing
- ✅ All 59 tests pass successfully
- ✅ Backward compatibility maintained with v12 format
- ✅ Updated tests to verify correct behavior

## Impact
These changes ensure OpenTDFKit complies with the NanoTDF specification and enables interoperability with other compliant implementations.

🤖 Generated with [Claude Code](https://claude.ai/code)