### PR TITLE
Opt KAS requests into HTTP/3

### DIFF
--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -372,6 +372,7 @@ public class KASRewrapClient: KASRewrapClientProtocol {
         var request = URLRequest(url: rewrapEndpoint)
         request.httpMethod = "POST"
         request.timeoutInterval = 30
+        request.assumesHTTP3Capable = true // KAS advertises alt-svc: h3; falls back to HTTP/2
 
         request.addValue("Bearer \(oauthToken)", forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -505,6 +506,7 @@ public class KASRewrapClient: KASRewrapClientProtocol {
         var request = URLRequest(url: rewrapEndpoint)
         request.httpMethod = "POST"
         request.timeoutInterval = 30
+        request.assumesHTTP3Capable = true // KAS advertises alt-svc: h3; falls back to HTTP/2
         request.addValue("Bearer \(oauthToken)", forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         if endpoints.transport == .connect {
@@ -597,6 +599,7 @@ public class KASRewrapClient: KASRewrapClientProtocol {
             request.addValue("Bearer \(oauthToken)", forHTTPHeaderField: "Authorization")
             request.addValue("application/json", forHTTPHeaderField: "Accept")
         }
+        request.assumesHTTP3Capable = true // KAS advertises alt-svc: h3; falls back to HTTP/2
 
         let (data, response) = try await urlSession.data(for: request, delegate: noRedirect)
 


### PR DESCRIPTION
## Summary
Opt KAS requests into HTTP/3 on the first hop.

`assumesHTTP3Capable` is set on all three `KASRewrapClient` request sites — `rewrapNanoTDF`, `rewrapTDF`, and the KAS public-key fetch. The KAS endpoints (`platform.arkavo.net`, `kas.arkavo.net`) advertise `alt-svc: h3=":443"`, but a normal request starts on HTTP/2 and only upgrades a *later* connection. This flag lets the very first request negotiate HTTP/3; URLSession falls back to HTTP/2 automatically when a server is not h3-capable.

Note: `assumesHTTP3Capable` is a property on `URLRequest` (macOS 11.3+), not `URLSessionConfiguration`.

## Testing
- `swift build` ✅
- `swift test --filter KASRewrapClient` → **21/21 passed** ✅
- Runtime probe against `platform.arkavo.net`: `URLSessionTaskMetrics.networkProtocolName == "h3"` with the flag set (`h2` without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
