### PR TITLE
Fix audit bugs and remove v13 NanoTDF support

### DIFF
--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -238,14 +238,8 @@ public class BinaryParser {
             throw ParsingError.invalidFormat
         }
 
-        let policy: Policy
-        do {
-            guard let p = try readPolicyField(bindingMode: policyBindingConfig) else {
-                throw ParsingError.invalidFormat
-            }
-            policy = p
-        } catch {
-            throw error
+        guard let policy = try readPolicyField(bindingMode: policyBindingConfig) else {
+            throw ParsingError.invalidFormat
         }
 
         let ephemeralPublicKeySize = switch policyBindingConfig.curve {
@@ -289,14 +283,8 @@ public class BinaryParser {
             throw ParsingError.invalidFormat
         }
 
-        let policy: Policy
-        do {
-            guard let p = try readPolicyField(bindingMode: policyBindingConfig) else {
-                throw ParsingError.invalidFormat
-            }
-            policy = p
-        } catch {
-            throw error
+        guard let policy = try readPolicyField(bindingMode: policyBindingConfig) else {
+            throw ParsingError.invalidFormat
         }
 
         let ephemeralPublicKeySize = switch policyBindingConfig.curve {

--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -171,39 +171,10 @@ public class BinaryParser {
         return PolicyKeyAccess(resourceLocator: resourceLocator, ephemeralPublicKey: ephemeralPublicKey)
     }
 
-    /// Reads a PayloadKeyAccess structure and advances the cursor.
-    /// - Parameter version: The version of the NanoTDF format (v12 or v13)
-    /// - Returns: An initialized `PayloadKeyAccess` object if parsing is successful, otherwise `nil`.
-    func readPayloadKeyAccess(version: UInt8? = nil) -> PayloadKeyAccess? {
-        // 1. Parse KAS Endpoint Locator (ResourceLocator)
-        guard let kasEndpointLocator = readResourceLocator() else {
-            return nil
-        }
-
-        // 2. Read the curve byte
-        guard let curveRaw = readByte(),
-              let curve = Curve(rawValue: curveRaw)
-        else {
-            return nil
-        }
-
-        // For v12 format, we don't have a public key
-        if version == 0x4C { // v12 "L1L"
-            return PayloadKeyAccess(kasEndpointLocator: kasEndpointLocator, kasPublicKey: Data())
-        }
-
-        // For v13 format, read the key based on the curve size
-        let expectedPublicKeyLength = curve.publicKeyLength
-        guard expectedPublicKeyLength > 0 else { return nil }
-
-        // Read the public key
-        guard let kasPublicKey = read(length: expectedPublicKeyLength) else {
-            return nil
-        }
-
-        return PayloadKeyAccess(kasEndpointLocator: kasEndpointLocator, kasPublicKey: kasPublicKey)
-    }
-
+    /// Parses a NanoTDF header and advances the cursor.
+    /// Only v12 ("L1L") headers are accepted; v13 ("L1M") headers are rejected.
+    /// - Returns: An initialized `Header` object.
+    /// - Throws: `ParsingError` if the header is malformed or uses an unsupported version.
     public func parseHeader() throws -> Header {
         // Read the Magic Number first
         guard let magicNumber = read(length: FieldSize.magicNumberSize) else {
@@ -218,12 +189,13 @@ public class BinaryParser {
             throw ParsingError.invalidFormat
         }
 
-        // Branch based on version
+        // Branch based on version. v13 ("L1M") creation and rewrap support has been
+        // removed; only v12 ("L1L") NanoTDFs are supported.
         switch version {
         case 0x4C: // v12 "L1L"
             return try parseHeaderV12()
-        case 0x4D: // v13 "L1M"
-            return try parseHeaderV13()
+        case 0x4D: // v13 "L1M" — no longer supported
+            throw ParsingError.invalidVersion
         default:
             throw ParsingError.invalidVersion
         }
@@ -261,43 +233,6 @@ public class BinaryParser {
             kasEndpointLocator: kas,
             kasPublicKey: Data(), // For v12, KAS public key is empty.
         )
-
-        return Header(
-            payloadKeyAccess: payloadKeyAccess,
-            policyBindingConfig: policyBindingConfig,
-            payloadSignatureConfig: payloadSignatureConfig,
-            policy: policy,
-            ephemeralPublicKey: ephemeralPublicKey,
-        )
-    }
-
-    private func parseHeaderV13() throws -> Header {
-        // Parse the new three-field PayloadKeyAccess structure for v13
-        guard let payloadKeyAccess = readPayloadKeyAccess(version: 0x4D) else {
-            throw ParsingError.invalidKAS
-        }
-
-        guard let policyBindingConfig = readEccAndBindingMode(),
-              let payloadSignatureConfig = readSymmetricAndPayloadConfig()
-        else {
-            throw ParsingError.invalidFormat
-        }
-
-        guard let policy = try readPolicyField(bindingMode: policyBindingConfig) else {
-            throw ParsingError.invalidFormat
-        }
-
-        let ephemeralPublicKeySize = switch policyBindingConfig.curve {
-        case .secp256r1:
-            33
-        case .secp384r1:
-            49
-        case .secp521r1:
-            67
-        }
-        guard let ephemeralPublicKey = read(length: ephemeralPublicKeySize) else {
-            throw ParsingError.invalidFormat
-        }
 
         return Header(
             payloadKeyAccess: payloadKeyAccess,

--- a/OpenTDFKit/BinaryParser.swift
+++ b/OpenTDFKit/BinaryParser.swift
@@ -9,9 +9,8 @@ public class BinaryParser {
     }
 
     func read(length: Int) -> Data? {
-        guard length > 0 else { return nil }
+        guard length >= 0 else { return nil }
         guard cursor >= 0 else { return nil }
-        guard !data.isEmpty else { return nil }
         guard cursor + length <= data.count else { return nil }
         let range = cursor ..< (cursor + length)
         cursor += length
@@ -62,7 +61,7 @@ public class BinaryParser {
         return ResourceLocator(protocolEnum: protocolEnumValue, body: bodyString, identifier: identifier)
     }
 
-    private func readPolicyField(bindingMode: PolicyBindingConfig) -> Policy? {
+    private func readPolicyField(bindingMode: PolicyBindingConfig) throws -> Policy? {
         guard let policyTypeByte = readByte(),
               let policyType = Policy.PolicyType(rawValue: policyTypeByte)
         else {
@@ -72,46 +71,40 @@ public class BinaryParser {
         switch policyType {
         case .remote:
             guard let resourceLocator = readResourceLocator() else {
-                print("Failed to read Remote Policy resource locator")
-                return nil
+                throw ParsingError.invalidPolicy
             }
             // Binding
             guard let binding = readPolicyBinding(bindingMode: bindingMode) else {
-                print("Failed to read Remote Policy binding")
-                return nil
+                throw ParsingError.invalidPolicy
             }
             return Policy(type: .remote, body: nil, remote: resourceLocator, binding: binding)
         case .embeddedPlaintext, .embeddedEncrypted, .embeddedEncryptedWithPolicyKeyAccess:
-            let policyData = readEmbeddedPolicyBody(policyType: policyType, bindingMode: bindingMode)
+            let policyData = try readEmbeddedPolicyBody(policyType: policyType, bindingMode: bindingMode)
             // Binding
             guard let binding = readPolicyBinding(bindingMode: bindingMode) else {
-                print("Failed to read Remote Policy binding")
-                return nil
+                throw ParsingError.invalidPolicy
             }
             return Policy(type: policyType, body: policyData, remote: nil, binding: binding)
         }
     }
 
-    private func readEmbeddedPolicyBody(policyType: Policy.PolicyType, bindingMode: PolicyBindingConfig) -> EmbeddedPolicyBody? {
+    private func readEmbeddedPolicyBody(policyType: Policy.PolicyType, bindingMode: PolicyBindingConfig) throws -> EmbeddedPolicyBody? {
         guard let contentLengthData = read(length: 2)
         else {
-            print("Failed to read Embedded Policy content length")
-            return nil
+            throw ParsingError.invalidPolicy
         }
         let plaintextCiphertextLengthData = contentLengthData.prefix(2)
 
         let bytes = Array(plaintextCiphertextLengthData)
         let contentLength = (UInt16(bytes[0]) << 8) | UInt16(bytes[1])
 
-        // if no policy added then no read
         // Note 3.4.2.3.2 Body for Embedded Policy states Minimum Length is 1
         if contentLength == 0 {
-            return EmbeddedPolicyBody(body: Data([0x00]), keyAccess: nil)
+            throw ParsingError.invalidPolicy
         }
 
         guard let plaintextCiphertext = read(length: Int(contentLength)) else {
-            print("Failed to read Embedded Policy plaintext / ciphertext")
-            return nil
+            throw ParsingError.invalidPolicy
         }
         // Policy Key Access
         let keyAccess = policyType == .embeddedEncryptedWithPolicyKeyAccess ? readPolicyKeyAccess(bindingMode: bindingMode) : nil
@@ -121,14 +114,12 @@ public class BinaryParser {
 
     func readEccAndBindingMode() -> PolicyBindingConfig? {
         guard let eccAndBindingMode = readByte() else {
-            print("Failed to read BindingMode")
             return nil
         }
         let ecdsaBinding = (eccAndBindingMode & (1 << 7)) != 0
         let ephemeralECCParamsEnumValue = Curve(rawValue: eccAndBindingMode & 0x7)
 
         guard let ephemeralECCParamsEnum = ephemeralECCParamsEnumValue else {
-            print("Unsupported Ephemeral ECC Params Enum value")
             return nil
         }
 
@@ -242,10 +233,19 @@ public class BinaryParser {
         // Parse the legacy single-field ResourceLocator KAS for v12
         guard let kas = readResourceLocator(),
               let policyBindingConfig = readEccAndBindingMode(),
-              let payloadSignatureConfig = readSymmetricAndPayloadConfig(),
-              let policy = readPolicyField(bindingMode: policyBindingConfig)
+              let payloadSignatureConfig = readSymmetricAndPayloadConfig()
         else {
             throw ParsingError.invalidFormat
+        }
+
+        let policy: Policy
+        do {
+            guard let p = try readPolicyField(bindingMode: policyBindingConfig) else {
+                throw ParsingError.invalidFormat
+            }
+            policy = p
+        } catch {
+            throw error
         }
 
         let ephemeralPublicKeySize = switch policyBindingConfig.curve {
@@ -284,10 +284,19 @@ public class BinaryParser {
         }
 
         guard let policyBindingConfig = readEccAndBindingMode(),
-              let payloadSignatureConfig = readSymmetricAndPayloadConfig(),
-              let policy = readPolicyField(bindingMode: policyBindingConfig)
+              let payloadSignatureConfig = readSymmetricAndPayloadConfig()
         else {
             throw ParsingError.invalidFormat
+        }
+
+        let policy: Policy
+        do {
+            guard let p = try readPolicyField(bindingMode: policyBindingConfig) else {
+                throw ParsingError.invalidFormat
+            }
+            policy = p
+        } catch {
+            throw error
         }
 
         let ephemeralPublicKeySize = switch policyBindingConfig.curve {
@@ -379,14 +388,12 @@ public class BinaryParser {
             publicKeyLength = 67
             signatureLength = 132
         case .none:
-            print("signatureECCMode not found")
             throw ParsingError.invalidFormat
         }
 
         guard let publicKey = read(length: publicKeyLength),
               let signature = read(length: signatureLength)
         else {
-            print("publicKey or signatureLength read error")
             throw ParsingError.invalidFormat
         }
         return Signature(publicKey: publicKey, signature: signature)

--- a/OpenTDFKit/CryptoHelper.swift
+++ b/OpenTDFKit/CryptoHelper.swift
@@ -229,10 +229,18 @@ public actor CryptoHelper {
     /// Generates a cryptographically secure random nonce (IV) of the specified length.
     /// - Parameter length: The desired length of the nonce in bytes. Defaults to `CryptoConstants.aesGcmNonceSize` (12 bytes).
     /// - Returns: The generated nonce as `Data`.
-    func generateNonce(length: Int = CryptoConstants.aesGcmNonceSize) -> Data {
+    func generateNonce(length: Int = CryptoConstants.aesGcmNonceSize) throws -> Data {
         var nonce = Data(count: length)
         // Use SecRandomCopyBytes for generating secure random data.
-        _ = nonce.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, length, $0.baseAddress!) }
+        let status = nonce.withUnsafeMutableBytes { buffer -> OSStatus in
+            guard let baseAddress = buffer.baseAddress else {
+                return errSecAllocate
+            }
+            return SecRandomCopyBytes(kSecRandomDefault, length, baseAddress)
+        }
+        guard status == errSecSuccess else {
+            throw CryptoHelperError.keyGenerationFailed
+        }
         return nonce
     }
 

--- a/OpenTDFKit/CryptoHelper.swift
+++ b/OpenTDFKit/CryptoHelper.swift
@@ -33,9 +33,7 @@ public enum CryptoHelperError: Error {
 enum CryptoConstants {
     /// HKDF salt for NanoTDF v12 ("L1L"), computed as SHA256(MAGIC_NUMBER + VERSION).
     static let hkdfSaltV12 = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
-    /// HKDF salt for NanoTDF v13 ("L1M"), computed as SHA256(MAGIC_NUMBER + VERSION).
-    static let hkdfSaltV13 = CryptoHelper.computeHKDFSalt(version: Header.version)
-    /// Default HKDF salt (prioritising v12 compatibility).
+    /// Default HKDF salt (v12 only; v13 creation has been removed).
     static let hkdfSalt = hkdfSaltV12
     /// Standard info tag used for HKDF key derivation for encryption keys in NanoTDF context.
     static let hkdfInfoEncryption = Data()
@@ -54,7 +52,7 @@ enum CryptoConstants {
 /// nonce handling, and signature generation.
 public actor CryptoHelper {
     /// Computes HKDF salt for a given NanoTDF version by hashing the magic number and version byte.
-    /// - Parameter version: The NanoTDF version byte (e.g. 0x4C for v12, 0x4D for v13).
+    /// - Parameter version: The NanoTDF version byte (currently 0x4C for v12).
     /// - Returns: The resulting salt as Data.
     static func computeHKDFSalt(version: UInt8) -> Data {
         let magicAndVersion = Header.magicNumber + Data([version])

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -26,7 +26,7 @@ public protocol KASRewrapClientProtocol {
 }
 
 /// Client for interacting with KAS rewrap endpoint for NanoTDF
-public class KASRewrapClient: KASRewrapClientProtocol {
+public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
     // MARK: - Request/Response Structures
 
     /// Key Access Object for NanoTDF rewrap
@@ -352,7 +352,7 @@ public class KASRewrapClient: KASRewrapClientProtocol {
         )
 
         // Build the unsigned request with clientPublicKey at top level
-        let clientPublicKeyPEM = String(data: clientKeyPair.publicKey, encoding: .utf8) ?? ""
+        let clientPublicKeyPEM = try Self.pemRepresentation(compressedPublicKey: clientKeyPair.publicKey)
         let unsignedRequest = UnsignedRewrapRequest(
             clientPublicKey: clientPublicKeyPEM,
             requests: [requestEntry],
@@ -439,6 +439,9 @@ public class KASRewrapClient: KASRewrapClientProtocol {
         let clientPublicKeyPEM = clientPrivateKey.publicKey.pemRepresentation
 
         let policyBody = manifest.encryptionInformation.policy
+        guard !policyBody.isEmpty, Data(base64Encoded: policyBody) != nil else {
+            throw KASRewrapError.invalidTDFRequest("Policy must be non-empty base64")
+        }
         let keyAccessEntries = manifest.encryptionInformation.keyAccess.filter { matchesKasURL($0.url) }
 
         guard !keyAccessEntries.isEmpty else {
@@ -562,8 +565,8 @@ public class KASRewrapClient: KASRewrapClientProtocol {
     public func fetchKasEcPublicKey(
         algorithm: RewrapAlgorithm = .ecP256,
     ) async throws -> KasEcPublicKeyResult {
-        // Validate algorithm is EC-based
-        guard algorithm == .ecP256 || algorithm == .ecP384 || algorithm == .ecP521 else {
+        // Only P-256 validation/parsing is currently implemented.
+        guard algorithm == .ecP256 else {
             throw KASRewrapError.unsupportedKeyAlgorithm(algorithm.rawValue)
         }
 
@@ -836,6 +839,29 @@ public class KASRewrapClient: KASRewrapClientProtocol {
         let sealedBox = try AES.GCM.SealedBox(combined: wrappedKey)
         let decryptedKey = try AES.GCM.open(sealedBox, using: symmetricKey)
         return SymmetricKey(data: decryptedKey)
+    }
+
+    /// Convert a 33-byte compressed P-256 public key to PEM (SubjectPublicKeyInfo) format.
+    /// - Parameter compressedPublicKey: The 33-byte compressed EC point.
+    /// - Returns: A PEM-encoded public key string.
+    /// - Throws: KASRewrapError if the input is not a valid compressed P-256 key.
+    public static func pemRepresentation(compressedPublicKey: Data) throws -> String {
+        guard compressedPublicKey.count == 33 else {
+            throw KASRewrapError.invalidEcPublicKey("Expected 33-byte compressed P-256 key, got \(compressedPublicKey.count)")
+        }
+
+        let publicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: compressedPublicKey)
+        let derData = publicKey.derRepresentation
+        let base64String = derData.base64EncodedString(options: [
+            .lineLength64Characters,
+            .endLineWithLineFeed,
+        ])
+
+        return """
+        -----BEGIN PUBLIC KEY-----
+        \(base64String)
+        -----END PUBLIC KEY-----
+        """
     }
 
     /// Extract compressed P256 public key from PEM format

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -267,9 +267,16 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         }
     }
 
+    /// A validated KAS EC public key, typed by curve.
+    public enum KasEcPublicKey: Sendable {
+        case p256(P256.KeyAgreement.PublicKey)
+        case p384(P384.KeyAgreement.PublicKey)
+        case p521(P521.KeyAgreement.PublicKey)
+    }
+
     /// Result of fetching and validating a KAS EC public key
     public struct KasEcPublicKeyResult {
-        /// Compressed P-256 public key (33 bytes)
+        /// Compressed public key bytes (33, 49, or 67 bytes depending on curve).
         public let compressedKey: Data
 
         /// The original PEM string from the KAS
@@ -278,8 +285,8 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         /// Key ID if provided by the KAS
         public let kid: String?
 
-        /// The parsed CryptoKit public key
-        public let cryptoKitKey: P256.KeyAgreement.PublicKey
+        /// The parsed CryptoKit public key, typed by curve.
+        public let key: KasEcPublicKey
     }
 
     // MARK: - Properties
@@ -565,8 +572,8 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
     public func fetchKasEcPublicKey(
         algorithm: RewrapAlgorithm = .ecP256,
     ) async throws -> KasEcPublicKeyResult {
-        // Only P-256 validation/parsing is currently implemented.
-        guard algorithm == .ecP256 else {
+        // Validate algorithm is EC-based
+        guard algorithm == .ecP256 || algorithm == .ecP384 || algorithm == .ecP521 else {
             throw KASRewrapError.unsupportedKeyAlgorithm(algorithm.rawValue)
         }
 
@@ -624,7 +631,7 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
                 compressedKey: result.compressedKey,
                 pem: keyResponse.publicKey,
                 kid: keyResponse.kid,
-                cryptoKitKey: result.cryptoKitKey,
+                key: result.key,
             )
         case 401:
             let message = String(data: data, encoding: .utf8)
@@ -640,21 +647,19 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         }
     }
 
-    /// Validate a PEM-encoded EC public key and extract the compressed representation
+    /// Validate a PEM-encoded EC public key and extract the compressed representation.
     /// - Parameters:
     ///   - pem: PEM-encoded public key string
-    ///   - expectedAlgorithm: The expected EC algorithm (for validation)
-    /// - Returns: Tuple containing compressed key data and CryptoKit public key
-    /// - Throws: KASRewrapError if validation fails
+    ///   - expectedAlgorithm: The expected EC algorithm (P-256, P-384, or P-521)
+    /// - Returns: Tuple containing compressed key data and a typed CryptoKit public key
+    /// - Throws: KASRewrapError if validation or parsing fails
     public static func validateEcPublicKeyPEM(
         _ pem: String,
         expectedAlgorithm: RewrapAlgorithm = .ecP256,
-    ) throws -> (compressedKey: Data, cryptoKitKey: P256.KeyAgreement.PublicKey) {
-        // Currently only P-256 is supported for validation
-        guard expectedAlgorithm == .ecP256 else {
-            throw KASRewrapError.unsupportedKeyAlgorithm(
-                "Validation only supports P-256, got: \(expectedAlgorithm.rawValue)",
-            )
+    ) throws -> (compressedKey: Data, key: KasEcPublicKey) {
+        // Validate algorithm is EC-based
+        guard expectedAlgorithm == .ecP256 || expectedAlgorithm == .ecP384 || expectedAlgorithm == .ecP521 else {
+            throw KASRewrapError.unsupportedKeyAlgorithm(expectedAlgorithm.rawValue)
         }
 
         // Normalize line endings and trim whitespace
@@ -694,49 +699,79 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
             throw KASRewrapError.invalidEcPublicKey("Invalid base64 encoding")
         }
 
-        // Parse public key - support multiple formats
-        // KAS server may return SEC1 bytes wrapped in SPKI PEM, or standard SPKI DER
-        let publicKey: P256.KeyAgreement.PublicKey
-
+        // Parse the key according to the expected curve and format.
         do {
-            if keyData.count == 65, keyData[0] == 0x04 {
-                // Raw uncompressed SEC1 point (0x04 || x || y) - 65 bytes
-                // This is the format some KAS servers return inside the PEM wrapper
-                publicKey = try P256.KeyAgreement.PublicKey(x963Representation: keyData)
-            } else if keyData.count == 33, keyData[0] == 0x02 || keyData[0] == 0x03 {
-                // Compressed SEC1 point (0x02/0x03 || x) - 33 bytes
-                publicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: keyData)
-            } else if keyData.count >= 59, keyData.count <= 91 {
-                // SPKI DER format (typically 91 bytes for P-256 with uncompressed point,
-                // or ~59 bytes with compressed point)
-                publicKey = try P256.KeyAgreement.PublicKey(derRepresentation: keyData)
-            } else {
-                throw KASRewrapError.invalidEcPublicKey(
-                    "Unrecognized key format: \(keyData.count) bytes",
-                )
+            switch expectedAlgorithm {
+            case .ecP256:
+                let publicKey = try parseP256PublicKey(keyData: keyData)
+                let compressedKey = publicKey.compressedRepresentation
+                try validateCompressedPoint(compressedKey, expectedSize: 33)
+                return (compressedKey, .p256(publicKey))
+            case .ecP384:
+                let publicKey = try parseP384PublicKey(keyData: keyData)
+                let compressedKey = publicKey.compressedRepresentation
+                try validateCompressedPoint(compressedKey, expectedSize: 49)
+                return (compressedKey, .p384(publicKey))
+            case .ecP521:
+                let publicKey = try parseP521PublicKey(keyData: keyData)
+                let compressedKey = publicKey.compressedRepresentation
+                try validateCompressedPoint(compressedKey, expectedSize: 67)
+                return (compressedKey, .p521(publicKey))
+            default:
+                throw KASRewrapError.unsupportedKeyAlgorithm(expectedAlgorithm.rawValue)
             }
         } catch let error as KASRewrapError {
             throw error
         } catch {
             throw KASRewrapError.invalidEcPublicKey("Failed to parse key: \(error.localizedDescription)")
         }
+    }
 
-        // Get compressed representation
-        let compressedKey = publicKey.compressedRepresentation
-
-        // Validate compressed key size (33 bytes for P-256)
-        guard compressedKey.count == 33 else {
-            throw KASRewrapError.invalidEcPublicKey("Invalid compressed key size: \(compressedKey.count), expected 33")
+    /// Parse a P-256 public key from raw SEC1 (compressed/uncompressed) or SPKI DER data.
+    private static func parseP256PublicKey(keyData: Data) throws -> P256.KeyAgreement.PublicKey {
+        if keyData.count == 65, keyData[0] == 0x04 {
+            try P256.KeyAgreement.PublicKey(x963Representation: keyData)
+        } else if keyData.count == 33, keyData[0] == 0x02 || keyData[0] == 0x03 {
+            try P256.KeyAgreement.PublicKey(compressedRepresentation: keyData)
+        } else {
+            try P256.KeyAgreement.PublicKey(derRepresentation: keyData)
         }
+    }
 
-        // Validate first byte is valid compressed point prefix
+    /// Parse a P-384 public key from raw SEC1 (compressed/uncompressed) or SPKI DER data.
+    private static func parseP384PublicKey(keyData: Data) throws -> P384.KeyAgreement.PublicKey {
+        if keyData.count == 97, keyData[0] == 0x04 {
+            try P384.KeyAgreement.PublicKey(x963Representation: keyData)
+        } else if keyData.count == 49, keyData[0] == 0x02 || keyData[0] == 0x03 {
+            try P384.KeyAgreement.PublicKey(compressedRepresentation: keyData)
+        } else {
+            try P384.KeyAgreement.PublicKey(derRepresentation: keyData)
+        }
+    }
+
+    /// Parse a P-521 public key from raw SEC1 (compressed/uncompressed) or SPKI DER data.
+    private static func parseP521PublicKey(keyData: Data) throws -> P521.KeyAgreement.PublicKey {
+        if keyData.count == 133, keyData[0] == 0x04 {
+            try P521.KeyAgreement.PublicKey(x963Representation: keyData)
+        } else if keyData.count == 67, keyData[0] == 0x02 || keyData[0] == 0x03 {
+            try P521.KeyAgreement.PublicKey(compressedRepresentation: keyData)
+        } else {
+            try P521.KeyAgreement.PublicKey(derRepresentation: keyData)
+        }
+    }
+
+    /// Validate that compressed key bytes start with a valid point prefix and have the expected size.
+    private static func validateCompressedPoint(_ compressedKey: Data, expectedSize: Int) throws {
+        guard compressedKey.count == expectedSize else {
+            throw KASRewrapError.invalidEcPublicKey(
+                "Invalid compressed key size: \(compressedKey.count), expected \(expectedSize)",
+            )
+        }
         guard compressedKey[0] == 0x02 || compressedKey[0] == 0x03 else {
             throw KASRewrapError.invalidEcPublicKey(
                 "Invalid compressed point prefix: 0x\(String(format: "%02x", compressedKey[0]))",
             )
         }
-
-        return (compressedKey, publicKey)
     }
 
     // MARK: - Private Helpers

--- a/OpenTDFKit/KASService.swift
+++ b/OpenTDFKit/KASService.swift
@@ -152,7 +152,7 @@ public actor KASService {
         policyBinding: Data? = nil,
         attributes: [String: String]? = nil,
     ) async throws -> Data {
-        let rewrapEndpoint = baseURL.appendingPathComponent("rewrap")
+        let rewrapEndpoint = baseURL.appendingPathComponent("kas/v2/rewrap")
 
         var request = URLRequest(url: rewrapEndpoint)
         request.httpMethod = "POST"
@@ -211,7 +211,6 @@ public actor KASService {
         ephemeralPublicKey: Data,
         encryptedKey: Data,
         privateKeyData: Data,
-        version: UInt8? = nil,
     ) async throws -> (rewrappedKey: Data, newKeyPair: StoredKeyPair) {
         // 1. Derive shared secret using the client's ephemeral public key and KAS private key
         let sharedSecret: SharedSecret
@@ -233,31 +232,10 @@ public actor KASService {
             sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         }
 
-        // 2. Derive symmetric key for decryption
-        // Support both v12 and v13 salt values (computed via spec formula)
-        let primarySalt: Data
-        let fallbackSalt: Data?
-
-        if let version {
-            switch version {
-            case Header.versionV12:
-                primarySalt = CryptoConstants.hkdfSaltV12
-                fallbackSalt = CryptoConstants.hkdfSaltV13
-            case Header.version:
-                primarySalt = CryptoConstants.hkdfSaltV13
-                fallbackSalt = CryptoConstants.hkdfSaltV12
-            default:
-                primarySalt = CryptoConstants.hkdfSaltV13
-                fallbackSalt = CryptoConstants.hkdfSaltV12
-            }
-        } else {
-            primarySalt = CryptoConstants.hkdfSaltV13
-            fallbackSalt = CryptoConstants.hkdfSaltV12
-        }
-
+        // 2. Derive symmetric key for decryption using v12 salt only
         let primaryKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: primarySalt,
+            salt: CryptoConstants.hkdfSaltV12,
             sharedInfo: Data(), // Empty per spec section 4
             outputByteCount: 32,
         )
@@ -281,20 +259,7 @@ public actor KASService {
             tag: tag,
         )
 
-        // Try decryption with the primary key first, then fallback if needed
-        let decryptedKey: Data
-        do {
-            decryptedKey = try AES.GCM.open(sealedBox, using: primaryKey)
-        } catch {
-            guard let fallbackSalt else { throw KASServiceError.rewrapFailed }
-            let fallbackKey = sharedSecret.hkdfDerivedSymmetricKey(
-                using: SHA256.self,
-                salt: fallbackSalt,
-                sharedInfo: Data(),
-                outputByteCount: 32,
-            )
-            decryptedKey = try AES.GCM.open(sealedBox, using: fallbackKey)
-        }
+        let decryptedKey = try AES.GCM.open(sealedBox, using: primaryKey)
 
         // 5. Create new shared secret for rewrapping
         let newSharedSecret: SharedSecret
@@ -316,10 +281,10 @@ public actor KASService {
             newSharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
         }
 
-        // 6. Derive new symmetric key for encryption (using v13 format)
+        // 6. Derive new symmetric key for encryption (using v12 format)
         let newSymmetricKey = newSharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: CryptoConstants.hkdfSaltV13, // Always use v13 salt for new keys
+            salt: CryptoConstants.hkdfSaltV12,
             sharedInfo: Data(), // Empty per spec section 4
             outputByteCount: 32,
         )
@@ -385,7 +350,18 @@ public actor KASService {
             return false
         }
         let expectedTag = Data(fullTag.prefix(policyBinding.count))
-        return policyBinding == expectedTag
+        return constantTimeEquals(policyBinding, expectedTag)
+    }
+
+    /// Compares two byte collections in constant time to mitigate timing attacks.
+    /// Returns `true` if the collections are equal, `false` otherwise.
+    private func constantTimeEquals(_ lhs: Data, _ rhs: Data) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        var result: UInt8 = 0
+        for (a, b) in zip(lhs, rhs) {
+            result |= a ^ b
+        }
+        return result == 0
     }
 
     /// Process a key access request and report which key was used

--- a/OpenTDFKit/KASService.swift
+++ b/OpenTDFKit/KASService.swift
@@ -355,6 +355,7 @@ public actor KASService {
 
     /// Compares two byte collections in constant time to mitigate timing attacks.
     /// Returns `true` if the collections are equal, `false` otherwise.
+    /// The length comparison is intentionally not constant-time: the tag length is public.
     private func constantTimeEquals(_ lhs: Data, _ rhs: Data) -> Bool {
         guard lhs.count == rhs.count else { return false }
         var result: UInt8 = 0

--- a/OpenTDFKit/KeyStore.swift
+++ b/OpenTDFKit/KeyStore.swift
@@ -251,7 +251,7 @@ public actor KeyStore {
         }
     }
 
-    /// Derives the symmetric key for NanoTDF v13 payload decryption using ECDH.
+    /// Derives the symmetric key for NanoTDF payload decryption using ECDH.
     /// This function assumes the KeyStore holds the KAS's private key.
     ///
     /// - Parameters:
@@ -265,7 +265,7 @@ public actor KeyStore {
         return try await derivePayloadSymmetricKey(kasPublicKey: kasPublicKey, tdfEphemeralPublicKey: tdfEphemeralPublicKey)
     }
 
-    /// Derives the symmetric key for NanoTDF v13 payload decryption using ECDH.
+    /// Derives the symmetric key for NanoTDF payload decryption using ECDH.
     /// This function assumes the KeyStore holds the KAS's private key.
     ///
     /// - Parameters:

--- a/OpenTDFKit/KeyStore.swift
+++ b/OpenTDFKit/KeyStore.swift
@@ -23,15 +23,14 @@ public struct StoredKeyPair: Sendable {
 
     public var publicKey: Data {
         bytes.withUnsafeBufferPointer { buffer in
-            Data(bytes: buffer.baseAddress!, count: publicKeyLength)
+            Data(buffer.prefix(publicKeyLength))
         }
     }
 
     var privateKey: Data {
         bytes.withUnsafeBufferPointer { buffer in
-            let privateKeyStart = buffer.baseAddress!.advanced(by: publicKeyLength)
-            let privateKeyLength = buffer.count - publicKeyLength
-            return Data(bytes: privateKeyStart, count: privateKeyLength)
+            let privateKeyStart = buffer.index(buffer.startIndex, offsetBy: publicKeyLength)
+            return Data(buffer.suffix(from: privateKeyStart))
         }
     }
 

--- a/OpenTDFKit/NanoTDF.swift
+++ b/OpenTDFKit/NanoTDF.swift
@@ -334,8 +334,7 @@ public func addSignatureToNanoTDF(nanoTDF: inout NanoTDF, privateKey: P256.Signi
     nanoTDF.header.payloadSignatureConfig.signatureCurve = config.signatureCurve
 }
 
-/// Represents the KAS (Key Access Service) information structure in the NanoTDF header,
-/// as per NanoTDF Spec v13 ("L1M").
+/// Represents the KAS (Key Access Service) information structure in the NanoTDF header.
 public struct PayloadKeyAccess: Sendable {
     /// Locator for the KAS endpoint.
     public let kasLocator: ResourceLocator
@@ -392,10 +391,7 @@ public struct Header: Sendable {
     /// Version identifier for NanoTDF v12 ("L1L").
     public static let versionV12: UInt8 = 0x4C
 
-    /// Version identifier for NanoTDF v13 ("L1M").
-    public static let version: UInt8 = 0x4D
-
-    /// Key Access Service information, as per NanoTDF Spec v13.
+    /// Key Access Service information.
     public let payloadKeyAccess: PayloadKeyAccess
 
     /// Configuration for the policy binding (e.g., curve used, binding type).

--- a/OpenTDFKit/NanoTDF.swift
+++ b/OpenTDFKit/NanoTDF.swift
@@ -92,106 +92,7 @@ public struct NanoTDF: Sendable {
 /// - Throws: `CryptoHelperError` if key generation or derivation fails, or errors from `CryptoKit` during cryptographic operations.
 @available(*, deprecated, message: "NanoTDF is deprecated. Use TDFCBORBuilder instead. See docs/NANOTDF_MIGRATION.md")
 public func createNanoTDFv12(kas: KasMetadata, policy: inout Policy, plaintext: Data) async throws -> NanoTDF {
-    // Step 1: Generate an ephemeral key pair based on the KAS curve
-    guard let keyPair = await NanoTDF.sharedCryptoHelper.generateEphemeralKeyPair(curveType: kas.curve) else {
-        throw CryptoHelperError.keyDerivationFailed
-    }
-
-    // Step 2: Derive the shared secret using ECDH
-    let kasPublicKey = try kas.getPublicKey()
-    guard let sharedSecret = try await NanoTDF.sharedCryptoHelper.deriveSharedSecret(
-        keyPair: keyPair,
-        recipientPublicKey: kasPublicKey,
-    ) else {
-        throw CryptoHelperError.keyDerivationFailed
-    }
-
-    // Step 3: Derive the symmetric TDF key using HKDF with v1.2 salt
-    let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
-    let tdfSymmetricKey = await NanoTDF.sharedCryptoHelper.deriveSymmetricKey(
-        sharedSecret: sharedSecret,
-        salt: salt,
-        info: Data(),
-        outputByteCount: 32,
-    )
-    // Step 4: Process policy body based on type
-    let policyBody: Data
-    switch policy.type {
-    case .embeddedPlaintext, .remote:
-        policyBody = policy.body?.body ?? Data()
-    case .embeddedEncrypted, .embeddedEncryptedWithPolicyKeyAccess:
-        let plainPolicy = policy.body?.body ?? Data()
-        let zeroNonce = Data(count: 12)
-        let selectedCipher = Cipher.aes256GCM96
-        let (ciphertext, tag) = try CryptoHelper.encryptNanoTDF(
-            cipher: selectedCipher,
-            key: tdfSymmetricKey,
-            iv: zeroNonce,
-            plaintext: plainPolicy,
-        )
-        policyBody = ciphertext + tag
-    }
-
-    policy.body = EmbeddedPolicyBody(body: policyBody)
-
-    // Step 5: Calculate the policy binding
-    // NanoTDF v1.2 uses SHA256 hash of policy body bytes, taking last 8 bytes
-    let digest = SHA256.hash(data: policyBody)
-    policy.binding = Data(digest.suffix(8))
-
-    // Step 6: Configure cipher (use aes256GCM96 for otdfctl compatibility)
-    let selectedCipher = Cipher.aes256GCM96
-    let authTagSize = 12
-
-    // Step 7: Generate 3-byte IV for payload
-    var payloadIV = Data(count: 3)
-    let ivStatus = payloadIV.withUnsafeMutableBytes { buffer -> OSStatus in
-        guard let baseAddress = buffer.baseAddress else {
-            return errSecAllocate
-        }
-        return SecRandomCopyBytes(kSecRandomDefault, 3, baseAddress)
-    }
-    guard ivStatus == errSecSuccess else {
-        throw CryptoHelperError.keyGenerationFailed
-    }
-
-    // Step 8: Encrypt plaintext directly with the TDF symmetric key (no separate payload key)
-    // This is the key difference from v1.3 - we use the derived key directly
-    // Pad 3-byte IV to 12 bytes by appending zeros (must match adjustNonce in getPayloadPlaintext)
-    let fullIV = payloadIV + Data(count: 9)
-    let nonce = try AES.GCM.Nonce(data: fullIV)
-    let sealed = try AES.GCM.seal(plaintext, using: tdfSymmetricKey, nonce: nonce)
-    let mac = Data(sealed.tag.prefix(authTagSize))
-
-    // Create v1.2 header (empty KAS public key forces v1.2 format)
-    let payloadKeyAccess = PayloadKeyAccess(
-        kasEndpointLocator: kas.resourceLocator,
-        kasPublicKey: Data(), // Empty for v1.2 format
-    )
-
-    let header = Header(
-        payloadKeyAccess: payloadKeyAccess,
-        policyBindingConfig: PolicyBindingConfig(ecdsaBinding: false, curve: kas.curve),
-        payloadSignatureConfig: SignatureAndPayloadConfig(
-            signed: false,
-            signatureCurve: kas.curve,
-            payloadCipher: selectedCipher,
-        ),
-        policy: policy,
-        ephemeralPublicKey: keyPair.publicKey,
-    )
-
-    // Create payload WITHOUT wrapped key (per NanoTDF spec)
-    // Length field must include: IV (3 bytes) + ciphertext + MAC
-    let totalPayloadLength = UInt32(payloadIV.count + sealed.ciphertext.count + mac.count)
-    let payload = Payload(
-        length: totalPayloadLength,
-        iv: payloadIV,
-        ciphertext: sealed.ciphertext,
-        mac: mac,
-    )
-
-    return NanoTDF(header: header, payload: payload, signature: nil)
+    try await createNanoTDF(kas: kas, policy: &policy, plaintext: plaintext)
 }
 
 /// Creates a NanoTDF object by encrypting the provided plaintext.
@@ -222,7 +123,7 @@ public func createNanoTDF(kas: KasMetadata, policy: inout Policy, plaintext: Dat
 
     // Step 3: Derive the symmetric TDF key from the shared secret using HKDF
     // Salt is SHA256(MAGIC_NUMBER + VERSION) per spec section 4
-    let salt = CryptoHelper.computeHKDFSalt(version: Header.version) // v13 by default
+    let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12) // v12 only
     let tdfSymmetricKey = await NanoTDF.sharedCryptoHelper.deriveSymmetricKey(
         sharedSecret: sharedSecret,
         salt: salt,
@@ -355,7 +256,7 @@ public func createNanoTDF(kas: KasMetadata, policy: inout Policy, plaintext: Dat
     policy.binding = gmacTag
 
     // Step 4: Generate a 3-byte nonce/IV for the payload encryption
-    let nonce = await NanoTDF.sharedCryptoHelper.generateNonce(length: 3)
+    let nonce = try await NanoTDF.sharedCryptoHelper.generateNonce(length: 3)
     // Adjust the 3-byte nonce to 12 bytes for AES-GCM compatibility
     let nonce12 = await NanoTDF.sharedCryptoHelper.adjustNonce(nonce, to: 12)
 
@@ -378,13 +279,13 @@ public func createNanoTDF(kas: KasMetadata, policy: inout Policy, plaintext: Dat
         mac: tag, // Store the 16-byte authentication tag
     )
 
-    // Create the PayloadKeyAccess structure for v13 header
+    // Create the PayloadKeyAccess structure for v12 header
     let payloadKeyAccess = PayloadKeyAccess(
         kasEndpointLocator: kas.resourceLocator,
-        kasPublicKey: kasPublicKey, // Include the KAS public key in the header
+        kasPublicKey: Data(), // Empty for v12 format
     )
 
-    // Create the Header struct with v13 format
+    // Create the Header struct with v12 format
     let header = Header(
         payloadKeyAccess: payloadKeyAccess,
         policyBindingConfig: PolicyBindingConfig(ecdsaBinding: false, curve: kas.curve), // Assuming GMAC binding for now
@@ -445,13 +346,12 @@ public struct PayloadKeyAccess: Sendable {
     /// This is not stored as a separate field but computed from the public key length.
     public var kasKeyCurve: Curve {
         switch kasPublicKey.count {
-        case 33: return .secp256r1
-        case 49: return .secp384r1
-        case 67: return .secp521r1
-        case 0: return .secp256r1 // Default for empty keys (v12 format)
+        case 33: .secp256r1
+        case 49: .secp384r1
+        case 67: .secp521r1
+        case 0: .secp256r1 // Default for empty keys (v12 format)
         default:
-            print("Warning: Invalid KAS public key size: \(kasPublicKey.count)")
-            return .secp256r1 // Default to P-256 as a fallback
+            .secp256r1 // Default to P-256 as a fallback
         }
     }
 
@@ -541,26 +441,17 @@ public struct Header: Sendable {
         self.ephemeralPublicKey = ephemeralPublicKey
     }
 
-    /// Serializes the Header into its binary `Data` representation according to the NanoTDF specification.
-    /// Conditionally creates a v12 or v13 format header based on the state of `payloadKeyAccess.kasPublicKey`.
+    /// Serializes the Header into its binary `Data` representation according to the NanoTDF v12 specification.
+    /// Always creates a v12 ("L1L") header; v13 ("L1M") creation has been removed.
     /// - Returns: A `Data` object representing the serialized header.
     public func toData() -> Data {
         var data = Data()
         data.append(Header.magicNumber)
 
-        // If kasPublicKey is empty, this indicates a v12 style header structure
-        // (e.g., as parsed by BinaryParser for v12, or if explicitly constructed for v12).
-        if payloadKeyAccess.kasPublicKey.isEmpty {
-            // Serialize as v12 "L1L"
-            data.append(Header.versionV12) // Use 0x4C
-            data.append(payloadKeyAccess.kasLocator.toData()) // KAS URL only
-        } else {
-            // Serialize as v13 "L1M"
-            data.append(Header.version) // Use 0x4D
-            data.append(payloadKeyAccess.toData()) // KAS URL + Curve + KAS Public Key
-        }
+        // Serialize as v12 "L1L"
+        data.append(Header.versionV12) // Use 0x4C
+        data.append(payloadKeyAccess.kasLocator.toData()) // KAS URL only
 
-        // Common parts for both v12 and v13
         data.append(policyBindingConfig.toData())
         data.append(payloadSignatureConfig.toData())
         data.append(policy.toData())
@@ -706,14 +597,7 @@ public struct ResourceLocator: Sendable {
     /// - Returns: An initialized `ResourceLocator` or `nil` if the body length or identifier size is invalid.
     public init?(protocolEnum: ProtocolEnum, body: String, identifier: Data? = nil) {
         // Validate body length (1 to 255 bytes as per spec for body content)
-        // ResourceLocator body itself can be 0 length if Identifier is "None" (0x0) as per KAS Endpoint Locator spec.
-        // However, the general ResourceLocator spec (3.4.1) says Body is 1-255.
-        // The current implementation of ResourceLocator.toData() uses body.data(using: .utf8)
-        // and then UInt8(bodyData.count). If body is empty, bodyData.count is 0.
-        // This is consistent with KAS Endpoint Locator Identifier "None" (0x0) if body is empty.
-        // For now, stick to current validation which requires non-empty body.
-        // If an empty body is needed for "None" identifier, this init needs adjustment.
-        guard body.utf8.count <= 255 else {
+        guard !body.isEmpty, body.utf8.count <= 255 else {
             return nil
         }
 
@@ -723,14 +607,6 @@ public struct ResourceLocator: Sendable {
             guard validSizes.contains(identifier.count) else {
                 return nil // Invalid identifier size
             }
-        }
-
-        // Allow empty body for KAS endpoint with "None" identifier
-        if body.isEmpty, protocolEnum == .http || protocolEnum == .https {
-            // For KAS Endpoint Locator with "None" identifier, empty body is valid
-            // Continue with initialization
-        } else if body.isEmpty {
-            return nil
         }
         self.protocolEnum = protocolEnum
         self.body = body
@@ -905,12 +781,11 @@ public struct PolicyKeyAccess: Sendable {
     /// The curve used by this key access, inferred from the public key size.
     public var curve: Curve {
         switch ephemeralPublicKey.count {
-        case 33: return .secp256r1
-        case 49: return .secp384r1
-        case 67: return .secp521r1
+        case 33: .secp256r1
+        case 49: .secp384r1
+        case 67: .secp521r1
         default:
-            print("Warning: Invalid ephemeral public key size: \(ephemeralPublicKey.count)")
-            return .secp256r1 // Default to P-256 as a fallback
+            .secp256r1 // Default to P-256 as a fallback
         }
     }
 

--- a/OpenTDFKit/NanoTDFCollection.swift
+++ b/OpenTDFKit/NanoTDFCollection.swift
@@ -152,13 +152,13 @@ public struct CollectionItem: Sendable {
         3 + storage.count
     }
 
-    /// Convert 3-byte IV to 12-byte GCM nonce: [0,0,0,0,0,0,0,0,0,b1,b2,b3]
-    /// This matches the NanoTDF nonce padding convention
+    /// Convert 3-byte IV to 12-byte GCM nonce: [b1,b2,b3,0,0,0,0,0,0,0,0,0]
+    /// This matches CryptoHelper.adjustNonce and standard NanoTDF nonce padding.
     public func toGCMNonce() -> Data {
         var nonce = Data(count: 12)
-        nonce[9] = UInt8((ivCounter >> 16) & 0xFF)
-        nonce[10] = UInt8((ivCounter >> 8) & 0xFF)
-        nonce[11] = UInt8(ivCounter & 0xFF)
+        nonce[0] = UInt8((ivCounter >> 16) & 0xFF)
+        nonce[1] = UInt8((ivCounter >> 8) & 0xFF)
+        nonce[2] = UInt8(ivCounter & 0xFF)
         return nonce
     }
 
@@ -268,7 +268,7 @@ public actor NanoTDFCollection {
     private var ivCounter: UInt32 = 1
 
     /// Pre-allocated 12-byte nonce buffer (reused for each encryption)
-    /// Format: [0,0,0,0,0,0,0,0,0, iv[0], iv[1], iv[2]]
+    /// Format: [iv[0], iv[1], iv[2], 0,0,0,0,0,0,0,0,0]
     private var nonceBuffer: ContiguousArray<UInt8>
 
     // MARK: - Properties
@@ -338,10 +338,10 @@ public actor NanoTDFCollection {
             throw NanoTDFCollectionError.ivExhausted
         }
 
-        // Update nonce buffer with new IV (last 3 bytes)
-        nonceBuffer[9] = UInt8((iv >> 16) & 0xFF)
-        nonceBuffer[10] = UInt8((iv >> 8) & 0xFF)
-        nonceBuffer[11] = UInt8(iv & 0xFF)
+        // Update nonce buffer with new IV (first 3 bytes)
+        nonceBuffer[0] = UInt8((iv >> 16) & 0xFF)
+        nonceBuffer[1] = UInt8((iv >> 8) & 0xFF)
+        nonceBuffer[2] = UInt8(iv & 0xFF)
 
         // Use CryptoKit for 128-bit tags (fastest path)
         if configuration.cipher == .aes256GCM128 {

--- a/OpenTDFKit/NanoTDFCollectionDecryptor.swift
+++ b/OpenTDFKit/NanoTDFCollectionDecryptor.swift
@@ -100,8 +100,8 @@ public actor NanoTDFCollectionDecryptor {
             throw NanoTDFCollectionError.keyDerivationFailed("Failed to derive shared secret")
         }
 
-        // Derive symmetric key via HKDF
-        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
+        // Derive symmetric key via HKDF using v12 salt
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
         let symmetricKey = await cryptoHelper.deriveSymmetricKey(
             sharedSecret: sharedSecret,
             salt: salt,
@@ -129,11 +129,11 @@ public actor NanoTDFCollectionDecryptor {
     /// - Returns: The decrypted plaintext data
     /// - Throws: `NanoTDFCollectionError.decryptionFailed` if decryption fails
     public func decryptItem(_ item: CollectionItem) throws -> Data {
-        // Update nonce buffer with item's IV
+        // Update nonce buffer with item's IV (first 3 bytes)
         let iv = item.ivCounter
-        nonceBuffer[9] = UInt8((iv >> 16) & 0xFF)
-        nonceBuffer[10] = UInt8((iv >> 8) & 0xFF)
-        nonceBuffer[11] = UInt8(iv & 0xFF)
+        nonceBuffer[0] = UInt8((iv >> 16) & 0xFF)
+        nonceBuffer[1] = UInt8((iv >> 8) & 0xFF)
+        nonceBuffer[2] = UInt8(iv & 0xFF)
 
         // Use CryptoKit for 128-bit tags (fastest path)
         if cipher == .aes256GCM128 {

--- a/OpenTDFKit/TDF/TDFArchive.swift
+++ b/OpenTDFKit/TDF/TDFArchive.swift
@@ -98,7 +98,7 @@ public struct TDFArchiveReader {
 public struct TDFArchiveWriter {
     public var compressionMethod: ZIPFoundation.CompressionMethod
 
-    public init(compressionMethod: ZIPFoundation.CompressionMethod = .deflate) {
+    public init(compressionMethod: ZIPFoundation.CompressionMethod = .none) {
         self.compressionMethod = compressionMethod
     }
 

--- a/OpenTDFKit/TDF/TDFCBORContainer.swift
+++ b/OpenTDFKit/TDF/TDFCBORContainer.swift
@@ -150,7 +150,7 @@ public struct TDFCBORBuilder: Sendable {
 
         // Create key access object with EC ephemeral public key
         let keyAccessObject = TDFKeyAccessObject(
-            type: .wrapped,
+            type: .ecWrapped,
             url: kasURL.absoluteString,
             protocolValue: .kas,
             wrappedKey: ecWrapped.wrappedKey,
@@ -298,9 +298,14 @@ public struct TDFCBORDecryptor: Sendable {
             throw TDFCBORError.decryptionFailed("No key access objects found")
         }
 
-        let symmetricKey = try TDFCrypto.unwrapSymmetricKeyWithRSA(
+        guard let ephemeralPublicKey = keyAccess[0].ephemeralPublicKey else {
+            throw TDFCBORError.decryptionFailed("EC-wrapped key missing ephemeral public key")
+        }
+
+        let symmetricKey = try TDFCrypto.unwrapSymmetricKeyWithEC(
             privateKeyPEM: privateKeyPEM,
             wrappedKey: keyAccess[0].wrappedKey,
+            ephemeralPublicKey: ephemeralPublicKey,
         )
 
         return try decrypt(container: container, symmetricKey: symmetricKey)

--- a/OpenTDFKit/TDF/TDFCBORFormat.swift
+++ b/OpenTDFKit/TDF/TDFCBORFormat.swift
@@ -57,15 +57,20 @@ public enum TDFCBOREnums {
     public static let encryptionTypeSplit: UInt64 = 0
     public static let encryptionTypeRemote: UInt64 = 1
 
-    // Key access type: 0=wrapped, 1=remote
+    // Key access type: 0=wrapped, 1=remote, 2=remoteWrapped, 3=ecWrapped
     public static let keyAccessTypeWrapped: UInt64 = 0
     public static let keyAccessTypeRemote: UInt64 = 1
+    public static let keyAccessTypeRemoteWrapped: UInt64 = 2
+    public static let keyAccessTypeEcWrapped: UInt64 = 3
 
     /// Key protocol: 0=kas
     public static let keyProtocolKas: UInt64 = 0
 
-    /// Symmetric algorithm: 0=AES-256-GCM
+    /// Symmetric algorithm: 0=AES-256-GCM, 1=AES-128-GCM, 2=AES-256-CBC, 3=AES-128-CBC
     public static let symmetricAlgAes256Gcm: UInt64 = 0
+    public static let symmetricAlgAes128Gcm: UInt64 = 1
+    public static let symmetricAlgAes256Cbc: UInt64 = 2
+    public static let symmetricAlgAes128Cbc: UInt64 = 3
 
     // Hash/Signature algorithm
     public static let hashAlgHS256: UInt64 = 0
@@ -408,7 +413,12 @@ extension TDFCBOREnvelope {
     /// Encode a single key access object to CBOR
     private func encodeKeyAccessToCBOR(_ ka: TDFKeyAccessObject) throws -> CBOR {
         // Key access type enum
-        let kaTypeEnum: UInt64 = ka.type == .wrapped ? TDFCBOREnums.keyAccessTypeWrapped : TDFCBOREnums.keyAccessTypeRemote
+        let kaTypeEnum: UInt64 = switch ka.type {
+        case .wrapped: TDFCBOREnums.keyAccessTypeWrapped
+        case .remote: TDFCBOREnums.keyAccessTypeRemote
+        case .remoteWrapped: TDFCBOREnums.keyAccessTypeRemoteWrapped
+        case .ecWrapped: TDFCBOREnums.keyAccessTypeEcWrapped
+        }
 
         // Protocol enum: "kas" -> 0 (currently only kas is supported)
         let protocolEnum: UInt64 = TDFCBOREnums.keyProtocolKas
@@ -419,7 +429,7 @@ extension TDFCBOREnvelope {
         }
 
         // Encode policy binding
-        let bindingAlgEnum = hashAlgToEnum(ka.policyBinding.alg)
+        let bindingAlgEnum = try hashAlgToEnum(ka.policyBinding.alg)
         guard let bindingHashData = Data(base64Encoded: ka.policyBinding.hash) else {
             throw TDFCBORError.cborEncodingFailed("Invalid policy binding hash base64")
         }
@@ -455,8 +465,15 @@ extension TDFCBOREnvelope {
 
     /// Encode method to CBOR
     private func encodeMethodToCBOR(_ method: TDFMethodDescriptor) throws -> CBOR {
-        // Algorithm enum: "AES-256-GCM" -> 0 (currently only AES-256-GCM is supported)
-        let algEnum: UInt64 = TDFCBOREnums.symmetricAlgAes256Gcm
+        // Algorithm enum mapping
+        let algEnum: UInt64 = switch method.algorithm {
+        case "AES-256-GCM": TDFCBOREnums.symmetricAlgAes256Gcm
+        case "AES-128-GCM": TDFCBOREnums.symmetricAlgAes128Gcm
+        case "AES-256-CBC": TDFCBOREnums.symmetricAlgAes256Cbc
+        case "AES-128-CBC": TDFCBOREnums.symmetricAlgAes128Cbc
+        default:
+            throw TDFCBORError.cborEncodingFailed("Unsupported symmetric algorithm: \(method.algorithm)")
+        }
 
         // Decode IV from base64 to raw bytes
         guard let ivData = Data(base64Encoded: method.iv) else {
@@ -475,7 +492,7 @@ extension TDFCBOREnvelope {
     /// Encode integrity information to CBOR
     private func encodeIntegrityToCBOR(_ integrity: TDFIntegrityInformation) throws -> CBOR {
         // Encode root signature
-        let rootAlgEnum = hashAlgToEnum(integrity.rootSignature.alg)
+        let rootAlgEnum = try hashAlgToEnum(integrity.rootSignature.alg)
         guard let rootSigData = Data(base64Encoded: integrity.rootSignature.sig) else {
             throw TDFCBORError.cborEncodingFailed("Invalid root signature base64")
         }
@@ -486,7 +503,7 @@ extension TDFCBOREnvelope {
         ]
 
         // Segment hash algorithm enum
-        let segHashAlgEnum = hashAlgToEnum(integrity.segmentHashAlg)
+        let segHashAlgEnum = try hashAlgToEnum(integrity.segmentHashAlg)
 
         // Encode segments
         let segmentsArray: [CBOR] = try integrity.segments.map { seg in
@@ -522,7 +539,7 @@ extension TDFCBOREnvelope {
     }
 
     /// Convert hash algorithm string to enum value
-    private func hashAlgToEnum(_ alg: String) -> UInt64 {
+    private func hashAlgToEnum(_ alg: String) throws -> UInt64 {
         switch alg {
         case "HS256": TDFCBOREnums.hashAlgHS256
         case "HS384": TDFCBOREnums.hashAlgHS384
@@ -532,12 +549,13 @@ extension TDFCBOREnvelope {
         case "ES256": TDFCBOREnums.hashAlgES256
         case "ES384": TDFCBOREnums.hashAlgES384
         case "ES512": TDFCBOREnums.hashAlgES512
-        default: TDFCBOREnums.hashAlgHS256
+        default:
+            throw TDFCBORError.cborEncodingFailed("Unsupported hash algorithm: \(alg)")
         }
     }
 
     /// Convert enum value to hash algorithm string
-    private static func enumToHashAlg(_ val: UInt64) -> String {
+    private static func enumToHashAlg(_ val: UInt64) throws -> String {
         switch val {
         case TDFCBOREnums.hashAlgHS256: "HS256"
         case TDFCBOREnums.hashAlgHS384: "HS384"
@@ -547,7 +565,8 @@ extension TDFCBOREnvelope {
         case TDFCBOREnums.hashAlgES256: "ES256"
         case TDFCBOREnums.hashAlgES384: "ES384"
         case TDFCBOREnums.hashAlgES512: "ES512"
-        default: "HS256"
+        default:
+            throw TDFCBORError.cborDecodingFailed("Unsupported hash algorithm enum: \(val)")
         }
     }
 
@@ -803,7 +822,13 @@ extension TDFCBOREnvelope {
         if let typeValue = kaMap[.unsignedInt(UInt64(TDFCBORKeyAccessKey.type.rawValue))],
            case let .unsignedInt(typeEnum) = typeValue
         {
-            accessType = typeEnum == TDFCBOREnums.keyAccessTypeWrapped ? .wrapped : .remote
+            accessType = switch typeEnum {
+            case TDFCBOREnums.keyAccessTypeWrapped: .wrapped
+            case TDFCBOREnums.keyAccessTypeRemote: .remote
+            case TDFCBOREnums.keyAccessTypeRemoteWrapped: .remoteWrapped
+            case TDFCBOREnums.keyAccessTypeEcWrapped: .ecWrapped
+            default: .wrapped
+            }
         }
 
         // URL
@@ -875,7 +900,7 @@ extension TDFCBOREnvelope {
         if let algValue = pbMap[.unsignedInt(UInt64(TDFCBORPolicyBindingKey.alg.rawValue))],
            case let .unsignedInt(algEnum) = algValue
         {
-            alg = enumToHashAlg(algEnum)
+            alg = try enumToHashAlg(algEnum)
         }
 
         var hash = ""
@@ -890,8 +915,19 @@ extension TDFCBOREnvelope {
 
     /// Decode method from CBOR
     private static func decodeMethod(_ methodMap: [CBOR: CBOR]) throws -> TDFMethodDescriptor {
-        // Currently only AES-256-GCM is supported
-        let algorithm = "AES-256-GCM"
+        var algorithm = "AES-256-GCM"
+        if let algValue = methodMap[.unsignedInt(UInt64(TDFCBORMethodKey.algorithm.rawValue))],
+           case let .unsignedInt(algEnum) = algValue
+        {
+            algorithm = switch algEnum {
+            case TDFCBOREnums.symmetricAlgAes256Gcm: "AES-256-GCM"
+            case TDFCBOREnums.symmetricAlgAes128Gcm: "AES-128-GCM"
+            case TDFCBOREnums.symmetricAlgAes256Cbc: "AES-256-CBC"
+            case TDFCBOREnums.symmetricAlgAes128Cbc: "AES-128-CBC"
+            default:
+                throw TDFCBORError.cborDecodingFailed("Unsupported symmetric algorithm enum: \(algEnum)")
+            }
+        }
 
         var iv = ""
         if let ivValue = methodMap[.unsignedInt(UInt64(TDFCBORMethodKey.iv.rawValue))],
@@ -925,7 +961,7 @@ extension TDFCBOREnvelope {
         if let segAlgValue = intMap[.unsignedInt(UInt64(TDFCBORIntegrityKey.segmentHashAlg.rawValue))],
            case let .unsignedInt(segAlgEnum) = segAlgValue
         {
-            segmentHashAlg = enumToHashAlg(segAlgEnum)
+            segmentHashAlg = try enumToHashAlg(segAlgEnum)
         }
 
         // Segments
@@ -970,7 +1006,7 @@ extension TDFCBOREnvelope {
         if let algValue = sigMap[.unsignedInt(UInt64(TDFCBORRootSigKey.alg.rawValue))],
            case let .unsignedInt(algEnum) = algValue
         {
-            alg = enumToHashAlg(algEnum)
+            alg = try enumToHashAlg(algEnum)
         }
 
         var sig = ""

--- a/OpenTDFKit/TDF/TDFCrypto.swift
+++ b/OpenTDFKit/TDF/TDFCrypto.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import CryptoSwift
 import Foundation
+import Security
 
 /// Encryption mode for TDF payloads
 public enum TDFEncryptionMode: String, Sendable {
@@ -61,9 +62,17 @@ public enum TDFCrypto {
     }
 
     public static func randomBytes(count: Int) throws -> Data {
-        var generator = SystemRandomNumberGenerator()
-        let randomBytes = (0 ..< count).map { _ in UInt8.random(in: UInt8.min ... UInt8.max, using: &generator) }
-        return Data(randomBytes)
+        var bytes = Data(count: count)
+        let status = bytes.withUnsafeMutableBytes { buffer -> OSStatus in
+            guard let baseAddress = buffer.baseAddress else {
+                return errSecAllocate
+            }
+            return SecRandomCopyBytes(kSecRandomDefault, count, baseAddress)
+        }
+        guard status == errSecSuccess else {
+            throw TDFCryptoError.keyWrapFailed(nil)
+        }
+        return bytes
     }
 
     public static func encryptPayload(plaintext: Data, symmetricKey: SymmetricKey) throws -> (iv: Data, cipherText: Data, authenticationTag: Data) {
@@ -301,6 +310,25 @@ public enum TDFCrypto {
         case .p521:
             try wrapWithP521(publicKeyPEM: publicKeyPEM, symmetricKey: symmetricKey)
         }
+    }
+
+    /// Unwrap a symmetric key using EC (ECIES: ECDH + HKDF + AES-GCM).
+    /// - Parameters:
+    ///   - privateKeyPEM: The recipient's PEM-encoded EC private key
+    ///   - wrappedKey: The wrapped key data (base64-encoded nonce + ciphertext + tag)
+    ///   - ephemeralPublicKey: The sender's ephemeral public key (PEM or base64 SEC1 compressed)
+    /// - Returns: The unwrapped symmetric key
+    public static func unwrapSymmetricKeyWithEC(
+        privateKeyPEM: String,
+        wrappedKey: String,
+        ephemeralPublicKey ephemeralKeyString: String,
+    ) throws -> SymmetricKey {
+        let privateKey = try P256.KeyAgreement.PrivateKey(pemRepresentation: privateKeyPEM)
+        return try unwrapSymmetricKeyWithEC(
+            privateKey: privateKey,
+            wrappedKey: wrappedKey,
+            ephemeralPublicKey: ephemeralKeyString,
+        )
     }
 
     /// Unwrap a symmetric key using EC (ECIES: ECDH + HKDF + AES-GCM).

--- a/OpenTDFKit/TDF/TDFCrypto.swift
+++ b/OpenTDFKit/TDF/TDFCrypto.swift
@@ -70,7 +70,7 @@ public enum TDFCrypto {
             return SecRandomCopyBytes(kSecRandomDefault, count, baseAddress)
         }
         guard status == errSecSuccess else {
-            throw TDFCryptoError.keyWrapFailed(nil)
+            throw TDFCryptoError.randomGenerationFailed(status)
         }
         return bytes
     }
@@ -588,6 +588,7 @@ public enum TDFCryptoError: Error, CustomStringConvertible {
     case ecKeyAgreementFailed(String)
     case unsupportedCurve(String)
     case decryptionFailed(String)
+    case randomGenerationFailed(OSStatus?)
 
     public var description: String {
         switch self {
@@ -630,6 +631,11 @@ public enum TDFCryptoError: Error, CustomStringConvertible {
             return "Unsupported EC curve: \(curve)"
         case let .decryptionFailed(reason):
             return "Decryption failed: \(reason)"
+        case let .randomGenerationFailed(status):
+            if let status {
+                return "Random number generation failed with status \(status)"
+            }
+            return "Random number generation failed"
         }
     }
 }

--- a/OpenTDFKit/TDF/TDFFormatDetector.swift
+++ b/OpenTDFKit/TDF/TDFFormatDetector.swift
@@ -5,11 +5,10 @@ import Foundation
 /// Detects the format of TDF data by examining magic bytes and structure.
 /// Detection order: CBOR (magic bytes) → ZIP (magic bytes) → JSON (starts with '{')
 public enum TDFFormatDetector {
-    /// CBOR magic bytes: self-describe CBOR tag + map + key 1
-    /// D9 D9F7 = tag(55799) for self-describe CBOR
-    /// A5 = map(5) for 5 elements
-    /// 01 = unsigned int 1 (first key)
-    public static let cborMagic: [UInt8] = [0xD9, 0xD9, 0xF7, 0xA5]
+    /// CBOR magic bytes: self-describe CBOR tag.
+    /// D9 D9F7 = tag(55799) for self-describe CBOR.
+    /// The following byte must be a CBOR map (0xA0-0xBF).
+    public static let cborMagic: [UInt8] = [0xD9, 0xD9, 0xF7]
 
     /// ZIP magic bytes (PK signature)
     public static let zipMagic: [UInt8] = [0x50, 0x4B, 0x03, 0x04]
@@ -30,7 +29,9 @@ public enum TDFFormatDetector {
         // Check CBOR magic bytes first (definitive)
         if data.count >= 4 {
             let header = [UInt8](data.prefix(4))
-            if header == cborMagic {
+            let prefix = [UInt8](data.prefix(cborMagic.count))
+            // Match the self-describe CBOR tag and ensure the next byte is a CBOR map.
+            if prefix == cborMagic, header[cborMagic.count] & 0xE0 == 0xA0 {
                 return .cbor
             }
         }

--- a/OpenTDFKit/TDF/TDFJSONContainer.swift
+++ b/OpenTDFKit/TDF/TDFJSONContainer.swift
@@ -149,7 +149,7 @@ public struct TDFJSONBuilder: Sendable {
 
         // Create key access object with EC ephemeral public key
         let keyAccessObject = TDFKeyAccessObject(
-            type: .wrapped,
+            type: .ecWrapped,
             url: kasURL.absoluteString,
             protocolValue: .kas,
             wrappedKey: ecWrapped.wrappedKey,
@@ -305,9 +305,14 @@ public struct TDFJSONDecryptor: Sendable {
             throw TDFJSONError.decryptionFailed("No key access objects found")
         }
 
-        let symmetricKey = try TDFCrypto.unwrapSymmetricKeyWithRSA(
+        guard let ephemeralPublicKey = keyAccess[0].ephemeralPublicKey else {
+            throw TDFJSONError.decryptionFailed("EC-wrapped key missing ephemeral public key")
+        }
+
+        let symmetricKey = try TDFCrypto.unwrapSymmetricKeyWithEC(
             privateKeyPEM: privateKeyPEM,
             wrappedKey: keyAccess[0].wrappedKey,
+            ephemeralPublicKey: ephemeralPublicKey,
         )
 
         return try decrypt(container: container, symmetricKey: symmetricKey)

--- a/OpenTDFKit/TDF/TDFJSONFormat.swift
+++ b/OpenTDFKit/TDF/TDFJSONFormat.swift
@@ -201,7 +201,7 @@ public extension TDFJSONEnvelope {
             payload: TDFPayloadDescriptor(
                 type: .reference,
                 url: "inline",
-                protocolValue: .zip,
+                protocolValue: .https,
                 isEncrypted: true,
                 mimeType: payload.mimeType,
             ),

--- a/OpenTDFKitCLI/Commands.swift
+++ b/OpenTDFKitCLI/Commands.swift
@@ -259,17 +259,19 @@ enum Commands {
         let oauthToken = String(data: tokenData, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        // Fetch KAS public key - construct full URL for the API call
-        let kasFullURL = URL(string: "http://\(kasBody)/kas")!
+        // Fetch KAS public key - construct full URL for the API call, preserving the configured scheme
+        let scheme = kasURL.scheme ?? "http"
+        let kasFullURL = URL(string: "\(scheme)://\(kasBody)/kas")!
         let kasPublicKeyData = try await fetchKASPublicKey(
             kasURL: kasFullURL,
             token: oauthToken,
         )
         print("✓ Retrieved KAS public key")
 
-        // Create resource locator for KAS
+        // Create resource locator for KAS, matching the configured scheme
+        let protocolEnum: ProtocolEnum = scheme == "https" ? .https : .http
         guard let kasLocator = ResourceLocator(
-            protocolEnum: ProtocolEnum(rawValue: 0x00)!, // HTTP
+            protocolEnum: protocolEnum,
             body: kasBody,
             identifier: Data([0x65, 0x31]), // "e1" for EC key
         ) else {

--- a/OpenTDFKitTests/CryptoHelperTests.swift
+++ b/OpenTDFKitTests/CryptoHelperTests.swift
@@ -93,7 +93,7 @@ extension CryptoHelper {
         )
 
         // Generate nonce
-        let nonce = generateNonce()
+        let nonce = try generateNonce()
 
         // Encrypt payload
         let (ciphertext, tag) = try encryptPayload(

--- a/OpenTDFKitTests/IntegrationTests.swift
+++ b/OpenTDFKitTests/IntegrationTests.swift
@@ -70,7 +70,7 @@ final class IntegrationTests: XCTestCase {
         )
 
         XCTAssertNotNil(nanoTDF)
-        XCTAssertEqual(nanoTDF.header.toData()[2], Header.version, "NanoTDF should use latest version")
+        XCTAssertEqual(nanoTDF.header.toData()[2], Header.versionV12, "NanoTDF should use v12")
 
         let token = try await getOAuthToken()
 
@@ -205,7 +205,7 @@ final class IntegrationTests: XCTestCase {
         let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: nanoTDF.header.ephemeralPublicKey)
 
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
-        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
 
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,

--- a/OpenTDFKitTests/KASRewrapClientTests.swift
+++ b/OpenTDFKitTests/KASRewrapClientTests.swift
@@ -417,6 +417,42 @@ final class KASRewrapClientTests: XCTestCase {
         XCTAssertEqual(parsedCompressedKey, compressedKey)
     }
 
+    func testValidateEcPublicKeyPEMP256() throws {
+        let privateKey = P256.KeyAgreement.PrivateKey()
+        let pem = privateKey.publicKey.pemRepresentation
+        let result = try KASRewrapClient.validateEcPublicKeyPEM(pem, expectedAlgorithm: .ecP256)
+        XCTAssertEqual(result.compressedKey.count, 33)
+        if case .p256 = result.key {} else {
+            XCTFail("Expected p256 key")
+        }
+    }
+
+    func testValidateEcPublicKeyPEMP384() throws {
+        let privateKey = P384.KeyAgreement.PrivateKey()
+        let pem = privateKey.publicKey.pemRepresentation
+        let result = try KASRewrapClient.validateEcPublicKeyPEM(pem, expectedAlgorithm: .ecP384)
+        XCTAssertEqual(result.compressedKey.count, 49)
+        if case .p384 = result.key {} else {
+            XCTFail("Expected p384 key")
+        }
+    }
+
+    func testValidateEcPublicKeyPEMP521() throws {
+        let privateKey = P521.KeyAgreement.PrivateKey()
+        let pem = privateKey.publicKey.pemRepresentation
+        let result = try KASRewrapClient.validateEcPublicKeyPEM(pem, expectedAlgorithm: .ecP521)
+        XCTAssertEqual(result.compressedKey.count, 67)
+        if case .p521 = result.key {} else {
+            XCTFail("Expected p521 key")
+        }
+    }
+
+    func testValidateEcPublicKeyPEMRejectsWrongCurve() throws {
+        let privateKey = P384.KeyAgreement.PrivateKey()
+        let pem = privateKey.publicKey.pemRepresentation
+        XCTAssertThrowsError(try KASRewrapClient.validateEcPublicKeyPEM(pem, expectedAlgorithm: .ecP256))
+    }
+
     func testRewrapRequestContainsValidClientPublicKeyPEM() throws {
         // Build a minimal rewrap request by invoking the NanoTDF request builder path
         let header = Data([0x4C, 0x31, 0x4C])

--- a/OpenTDFKitTests/KASRewrapClientTests.swift
+++ b/OpenTDFKitTests/KASRewrapClientTests.swift
@@ -295,7 +295,7 @@ final class KASRewrapClientTests: XCTestCase {
     }
 
     func testRewrapRequestStructureSerialization() throws {
-        let header = Data([0x4C, 0x31, 0x4D])
+        let header = Data([0x4C, 0x31, 0x4C])
         let keyAccess = KASRewrapClient.KeyAccessObject(
             header: header.base64EncodedString(),
             url: "https://kas.example.com",

--- a/OpenTDFKitTests/KASRewrapClientTests.swift
+++ b/OpenTDFKitTests/KASRewrapClientTests.swift
@@ -397,6 +397,66 @@ final class KASRewrapClientTests: XCTestCase {
 
         XCTAssertEqual(hex, "010aff")
     }
+
+    func testClientPublicKeyPEMConversion() throws {
+        // Generate a compressed P-256 public key (33 bytes)
+        let privateKey = P256.KeyAgreement.PrivateKey()
+        let compressedKey = privateKey.publicKey.compressedRepresentation
+        XCTAssertEqual(compressedKey.count, 33)
+
+        // Convert to PEM using the client's helper
+        let pem = try KASRewrapClient.pemRepresentation(compressedPublicKey: compressedKey)
+
+        // Verify the PEM is non-empty and has the expected markers
+        XCTAssertFalse(pem.isEmpty)
+        XCTAssertTrue(pem.contains("-----BEGIN PUBLIC KEY-----"))
+        XCTAssertTrue(pem.contains("-----END PUBLIC KEY-----"))
+
+        // Verify the PEM can be parsed back to the same compressed key
+        let parsedCompressedKey = try client.extractCompressedKeyFromPEM(pem)
+        XCTAssertEqual(parsedCompressedKey, compressedKey)
+    }
+
+    func testRewrapRequestContainsValidClientPublicKeyPEM() throws {
+        // Build a minimal rewrap request by invoking the NanoTDF request builder path
+        let header = Data([0x4C, 0x31, 0x4C])
+        let keyAccess = KASRewrapClient.KeyAccessObject(
+            header: header.base64EncodedString(),
+            url: "https://kas.example.com",
+        )
+        let wrapper = KASRewrapClient.KeyAccessObjectWrapper(
+            keyAccessObjectId: "kao-0",
+            keyAccessObject: keyAccess,
+        )
+        let policy = KASRewrapClient.Policy(body: "test policy".data(using: .utf8)!.base64EncodedString())
+        let requestEntry = KASRewrapClient.RewrapRequestEntry(
+            policy: policy,
+            keyAccessObjects: [wrapper],
+        )
+
+        let clientPrivateKey = P256.KeyAgreement.PrivateKey()
+        let clientKeyPair = EphemeralKeyPair(
+            privateKey: clientPrivateKey.rawRepresentation,
+            publicKey: clientPrivateKey.publicKey.compressedRepresentation,
+            curve: .secp256r1,
+        )
+
+        let clientPublicKeyPEM = try KASRewrapClient.pemRepresentation(compressedPublicKey: clientKeyPair.publicKey)
+        XCTAssertFalse(clientPublicKeyPEM.isEmpty)
+        XCTAssertTrue(clientPublicKeyPEM.contains("-----BEGIN PUBLIC KEY-----"))
+
+        let unsignedRequest = KASRewrapClient.UnsignedRewrapRequest(
+            clientPublicKey: clientPublicKeyPEM,
+            requests: [requestEntry],
+        )
+
+        let encoder = JSONEncoder()
+        let jsonData = try encoder.encode(unsignedRequest)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let pemFromJSON = try XCTUnwrap(json["clientPublicKey"] as? String)
+        XCTAssertFalse(pemFromJSON.isEmpty)
+        XCTAssertTrue(pemFromJSON.contains("-----BEGIN PUBLIC KEY-----"))
+    }
 }
 
 extension Data {

--- a/OpenTDFKitTests/KASServiceBenchmarkTests.swift
+++ b/OpenTDFKitTests/KASServiceBenchmarkTests.swift
@@ -82,7 +82,7 @@ final class KASServiceBenchmarkTests: XCTestCase {
                 )
 
                 // Encrypt sample data with proper format
-                let nonce = await cryptoHelper.generateNonce()
+                let nonce = try await cryptoHelper.generateNonce()
                 let paddedNonce = await cryptoHelper.adjustNonce(nonce, to: 12)
                 let sealedBox = try AES.GCM.seal(plaintext, using: symmetricKey, nonce: AES.GCM.Nonce(data: paddedNonce))
 

--- a/OpenTDFKitTests/KASServiceTests.swift
+++ b/OpenTDFKitTests/KASServiceTests.swift
@@ -38,7 +38,7 @@ final class KASServiceTests: XCTestCase {
 
         // Verify the NanoTDF was created successfully
         XCTAssertNotNil(nanoTDF)
-        XCTAssertEqual(nanoTDF.header.toData()[2], Header.version, "NanoTDF header should be v13")
+        XCTAssertEqual(nanoTDF.header.toData()[2], Header.versionV12, "NanoTDF header should be v12")
         XCTAssertEqual(nanoTDF.header.payloadKeyAccess.kasLocator.body, kasMetadata.resourceLocator.body)
         XCTAssertNotNil(nanoTDF.payload.ciphertext)
 
@@ -63,7 +63,7 @@ final class KASServiceTests: XCTestCase {
 
         // Derive symmetric key using the same parameters as in createNanoTDF
         // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
-        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
 
         let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
@@ -126,7 +126,7 @@ final class KASServiceTests: XCTestCase {
             policy: &policy,
             plaintext: plaintext,
         )
-        XCTAssertEqual(nanoTDF.header.toData()[2], Header.version, "NanoTDF header should be v13")
+        XCTAssertEqual(nanoTDF.header.toData()[2], Header.versionV12, "NanoTDF header should be v12")
 
         // Extract the ephemeral public key from the NanoTDF
         let ephemeralPublicKey = nanoTDF.header.ephemeralPublicKey
@@ -144,8 +144,8 @@ final class KASServiceTests: XCTestCase {
         let privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateKeyData!)
         let clientPublicKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: ephemeralPublicKey)
 
-        // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
-        let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
+        // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec (v12 only)
+        let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
 
         // Derive the same shared secret that would be used in the TDF creation
         let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
@@ -259,9 +259,33 @@ final class KASServiceTests: XCTestCase {
      }
      */
 
-    func testRewrapKeyWithVersionHinting() async throws {
-        // Test that version hinting reduces cryptographic operations
+    func testRewrapKeyEndpointPath() async throws {
+        // Use a mock URLSession to capture the request URL without network I/O
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RewrapURLProtocol.self]
+        let session = URLSession(configuration: config)
 
+        let baseURL = URL(string: "https://kas.example.com")!
+        let kasService = KASService(keyStore: keyStore, baseURL: baseURL, urlSession: session)
+
+        let clientKey = P256.KeyAgreement.PrivateKey()
+        let wrappedKey = Data(count: 44) // enough bytes to pass initial length check
+
+        do {
+            _ = try await kasService.rewrapKey(
+                ephemeralPublicKey: clientKey.publicKey.compressedRepresentation,
+                encryptedSessionKey: wrappedKey,
+            )
+        } catch {
+            // We expect an error because the mock returns no valid response body
+        }
+
+        let requestURL = RewrapURLProtocol.lastRequestURL
+        XCTAssertNotNil(requestURL)
+        XCTAssertEqual(requestURL?.absoluteString, "https://kas.example.com/kas/v2/rewrap")
+    }
+
+    func testRewrapKeyInternalV12() async throws {
         // Create KAS service with P-256 keys
         let baseURL = URL(string: "https://kas.example.com")!
         let kasService = KASService(keyStore: keyStore, baseURL: baseURL)
@@ -281,18 +305,18 @@ final class KASServiceTests: XCTestCase {
         let kasPrivateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: kasKeyPair.privateKey)
         let sharedSecret = try kasPrivateKey.sharedSecretFromKeyAgreement(with: clientPrivateKey.publicKey)
 
-        // Test with v13 version hint
-        let saltV13 = CryptoHelper.computeHKDFSalt(version: Header.version)
-        let symmetricKeyV13 = sharedSecret.hkdfDerivedSymmetricKey(
+        // Use v12 salt (the only supported salt after v13 removal)
+        let saltV12 = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
+        let symmetricKeyV12 = sharedSecret.hkdfDerivedSymmetricKey(
             using: SHA256.self,
-            salt: saltV13,
+            salt: saltV12,
             sharedInfo: Data(),
             outputByteCount: 32,
         )
 
         // Encrypt the test key
         let gcmNonce = AES.GCM.Nonce()
-        let sealedBox = try AES.GCM.seal(testKeyData, using: symmetricKeyV13, nonce: gcmNonce)
+        let sealedBox = try AES.GCM.seal(testKeyData, using: symmetricKeyV12, nonce: gcmNonce)
 
         // Format encrypted key as expected by rewrapKeyInternal: nonce + ciphertext + tag
         var encryptedKey = Data()
@@ -302,37 +326,45 @@ final class KASServiceTests: XCTestCase {
         encryptedKey.append(sealedBox.ciphertext)
         encryptedKey.append(sealedBox.tag)
 
-        // Test rewrap with v13 hint - should succeed on first try
-        let (rewrappedKeyV13, newKeyPairV13) = try await kasService.rewrapKeyInternal(
+        // Test rewrap with v12 salt
+        let (rewrappedKey, newKeyPair) = try await kasService.rewrapKeyInternal(
             ephemeralPublicKey: clientPublicKey,
             encryptedKey: encryptedKey,
             privateKeyData: kasKeyPair.privateKey,
-            version: Header.version, // v13 hint
         )
 
-        XCTAssertNotNil(rewrappedKeyV13)
-        XCTAssertNotNil(newKeyPairV13)
-
-        // Test rewrap with v12 hint - should fallback to v13
-        let (rewrappedKeyV12, newKeyPairV12) = try await kasService.rewrapKeyInternal(
-            ephemeralPublicKey: clientPublicKey,
-            encryptedKey: encryptedKey,
-            privateKeyData: kasKeyPair.privateKey,
-            version: Header.versionV12, // v12 hint
-        )
-
-        XCTAssertNotNil(rewrappedKeyV12)
-        XCTAssertNotNil(newKeyPairV12)
-
-        // Test rewrap with no hint - should try v13 first
-        let (rewrappedKeyNoHint, newKeyPairNoHint) = try await kasService.rewrapKeyInternal(
-            ephemeralPublicKey: clientPublicKey,
-            encryptedKey: encryptedKey,
-            privateKeyData: kasKeyPair.privateKey,
-            version: nil, // No hint
-        )
-
-        XCTAssertNotNil(rewrappedKeyNoHint)
-        XCTAssertNotNil(newKeyPairNoHint)
+        XCTAssertFalse(rewrappedKey.isEmpty)
+        XCTAssertFalse(newKeyPair.publicKey.isEmpty)
+        XCTAssertFalse(newKeyPair.privateKey.isEmpty)
     }
+}
+
+// MARK: - Mock URLProtocol for rewrap endpoint verification
+
+final class RewrapURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var lastRequestURL: URL?
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        RewrapURLProtocol.lastRequestURL = request.url
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"],
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let body = Data("{\"rewrapped_key\":\"dGVzdA==\"}".utf8)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/OpenTDFKitTests/KASServiceTests.swift
+++ b/OpenTDFKitTests/KASServiceTests.swift
@@ -228,8 +228,8 @@ final class KASServiceTests: XCTestCase {
          let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: clientPublicKey)
 
          // Compute salt as SHA256(MAGIC_NUMBER + VERSION) per spec
-         // Using v13 (L1M) since createNanoTDF uses v13 by default
-         let salt = CryptoHelper.computeHKDFSalt(version: Header.version)
+         // Using v12 (L1L) since createNanoTDF uses v12 only
+         let salt = CryptoHelper.computeHKDFSalt(version: Header.versionV12)
 
          let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
              using: SHA256.self,

--- a/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
+++ b/OpenTDFKitTests/NanoTDFBenchmarkTests.swift
@@ -121,7 +121,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
                     info: Data("benchmark".utf8),
                 )
 
-                let nonce = await cryptoHelper.generateNonce()
+                let nonce = try await cryptoHelper.generateNonce()
                 _ = try await cryptoHelper.encryptPayload(
                     plaintext: plaintext,
                     symmetricKey: symmetricKey,
@@ -142,7 +142,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let plaintext = String(repeating: "Test message for decryption benchmark. ", count: 100).data(using: .utf8)!
 
         let symmetricKey = SymmetricKey(size: .bits256)
-        let nonce = await cryptoHelper.generateNonce()
+        let nonce = try await cryptoHelper.generateNonce()
         let (ciphertext, tag) = try await cryptoHelper.encryptPayload(
             plaintext: plaintext,
             symmetricKey: symmetricKey,
@@ -234,7 +234,7 @@ final class NanoTDFBenchmarkTests: XCTestCase {
         let binding = try await cryptoHelper.createGMACBinding(policyBody: policyBody, symmetricKey: symmetricKey)
 
         // 4. Encrypt payload
-        let nonce = await cryptoHelper.generateNonce()
+        let nonce = try await cryptoHelper.generateNonce()
         let (ciphertext, tag) = try await cryptoHelper.encryptPayload(
             plaintext: plaintext,
             symmetricKey: symmetricKey,

--- a/OpenTDFKitTests/NanoTDFCollectionTests.swift
+++ b/OpenTDFKitTests/NanoTDFCollectionTests.swift
@@ -50,14 +50,14 @@ final class NanoTDFCollectionTests: XCTestCase {
 
         let nonce = item.toGCMNonce()
         XCTAssertEqual(nonce.count, 12)
-        // First 9 bytes should be zero
-        for i in 0 ..< 9 {
+        // First 3 bytes should match IV
+        XCTAssertEqual(nonce[0], 0x01)
+        XCTAssertEqual(nonce[1], 0x02)
+        XCTAssertEqual(nonce[2], 0x03)
+        // Last 9 bytes should be zero
+        for i in 3 ..< 12 {
             XCTAssertEqual(nonce[i], 0)
         }
-        // Last 3 bytes should match IV
-        XCTAssertEqual(nonce[9], 0x01)
-        XCTAssertEqual(nonce[10], 0x02)
-        XCTAssertEqual(nonce[11], 0x03)
     }
 
     // MARK: - IV Counter Tests
@@ -201,6 +201,36 @@ final class NanoTDFCollectionTests: XCTestCase {
         let decryptor = try await NanoTDFCollectionDecryptor.withKeyStore(
             header: header,
             keyStore: keyStore,
+        )
+
+        // Decrypt
+        let decryptedPlaintext = try await decryptor.decryptItem(item)
+
+        XCTAssertEqual(decryptedPlaintext, originalPlaintext)
+    }
+
+    func testPrivateKeyDecryptor() async throws {
+        let policyLocator = ResourceLocator(protocolEnum: .https, body: "kas.example.com/policy")!
+        let collection = try await NanoTDFCollectionBuilder()
+            .kasMetadata(kasMetadata)
+            .policy(.remote(policyLocator))
+            .build()
+
+        let originalPlaintext = "Private-key decryption test".data(using: .utf8)!
+
+        // Encrypt
+        let item = try await collection.encryptItem(plaintext: originalPlaintext)
+        let header = await collection.header
+
+        // Retrieve the KAS private key directly from the KeyStore
+        let kasPrivateKey = await keyStore.getPrivateKey(forPublicKey: header.payloadKeyAccess.kasPublicKey)
+        let kasPrivateKeyData = try XCTUnwrap(kasPrivateKey)
+
+        // Create KAS-side decryptor using raw private key
+        let decryptor = try await NanoTDFCollectionDecryptor.withPrivateKey(
+            header: header,
+            kasPrivateKeyData: kasPrivateKeyData,
+            curve: .secp256r1,
         )
 
         // Decrypt

--- a/OpenTDFKitTests/NanoTDFTests.swift
+++ b/OpenTDFKitTests/NanoTDFTests.swift
@@ -262,6 +262,31 @@ final class NanoTDFTests: XCTestCase {
         }
     }
 
+    func testZeroLengthEmbeddedPolicyBodyFails() throws {
+        // Build a minimal v12 header with an embedded plaintext policy whose body length is 0.
+        // Magic + version + KAS locator + binding config + payload config + policy type (embeddedPlaintext=0x01)
+        // + 2-byte body length 0x0000.
+        let kasLocator = ResourceLocator(protocolEnum: .http, body: "kas.example.com")!
+        var data = Data()
+        data.append(Header.magicNumber)
+        data.append(Header.versionV12)
+        data.append(kasLocator.toData())
+        data.append(PolicyBindingConfig(ecdsaBinding: false, curve: .secp256r1).toData())
+        data.append(SignatureAndPayloadConfig(signed: false, signatureCurve: nil, payloadCipher: .aes256GCM128).toData())
+        data.append(Policy.PolicyType.embeddedPlaintext.rawValue)
+        data.append(contentsOf: [0x00, 0x00]) // zero-length body
+
+        let parser = BinaryParser(data: data)
+        XCTAssertThrowsError(try parser.parseHeader()) { error in
+            guard let parsingError = error as? ParsingError,
+                  case .invalidPolicy = parsingError
+            else {
+                XCTFail("Expected ParsingError.invalidPolicy, got \(error)")
+                return
+            }
+        }
+    }
+
     func testNoPolicyBinaryParser() throws {
         let stringWithSpaces = """
         4c 31 4c 01 1a 70 6c 61 74 66 6f 72 6d 2e 76 69 72 74 72 75

--- a/OpenTDFKitTests/NanoTDFTests.swift
+++ b/OpenTDFKitTests/NanoTDFTests.swift
@@ -124,10 +124,10 @@ final class NanoTDFTests: XCTestCase {
             }.joined()
             print("Actual:")
             print(serializedNanoTDFHexString)
-            // We now generate v13 format TDFs (4c 31 4d) but the test was written for v12 (4c 31 4c)
-            // Just check that the serialized data starts with the magic number and has a version
+            // NanoTDF creation now only generates v12 format (4c 31 4c).
+            // Just check that the serialized data starts with the magic number and version.
             XCTAssertEqual(serializedNanoTDF.prefix(2), Data([0x4C, 0x31]), "Magic number should match")
-            XCTAssertTrue(serializedNanoTDF[2] == 0x4C || serializedNanoTDF[2] == 0x4D, "Version should be either 0x4C (v12) or 0x4D (v13)")
+            XCTAssertEqual(serializedNanoTDF[2], 0x4C, "Version should be 0x4C (v12)")
             print("NanoTDF has correct magic number and version.")
             // back again
             let bparser = BinaryParser(data: serializedNanoTDF)

--- a/OpenTDFKitTests/TDFTests.swift
+++ b/OpenTDFKitTests/TDFTests.swift
@@ -870,4 +870,90 @@ final class StandardTDFTests: XCTestCase {
             "Default algorithm should be AES-256-GCM",
         )
     }
+
+    // MARK: - TDF-JSON / TDF-CBOR EC round-trip tests
+
+    func testTDFJSONRoundTripWithECPrivateKey() throws {
+        let keyPair = generateTestECKeyPair()
+        let policy = try TDFPolicy(json: """
+        {"uuid":"test-policy","body":{"dataAttributes":[],"dissem":[]}}
+        """.data(using: .utf8)!)
+
+        let result = try TDFJSONBuilder()
+            .kasURL(URL(string: "http://localhost:8080/kas")!)
+            .kasPublicKey(keyPair.publicKeyPEM)
+            .policy(policy)
+            .encrypt(plaintext: testPlaintext)
+
+        XCTAssertEqual(result.container.encryptionInformation.keyAccess.first?.type, .ecWrapped)
+
+        let decrypted = try TDFJSONDecryptor().decrypt(
+            container: result.container,
+            privateKeyPEM: keyPair.privateKeyPEM,
+        )
+        XCTAssertEqual(decrypted, testPlaintext)
+    }
+
+    func testTDFCBORRoundTripWithECPrivateKey() throws {
+        let keyPair = generateTestECKeyPair()
+        let policy = try TDFPolicy(json: """
+        {"uuid":"test-policy","body":{"dataAttributes":[],"dissem":[]}}
+        """.data(using: .utf8)!)
+
+        let result = try TDFCBORBuilder()
+            .kasURL(URL(string: "http://localhost:8080/kas")!)
+            .kasPublicKey(keyPair.publicKeyPEM)
+            .policy(policy)
+            .encrypt(plaintext: testPlaintext)
+
+        XCTAssertEqual(result.container.encryptionInformation.keyAccess.first?.type, .ecWrapped)
+
+        let decrypted = try TDFCBORDecryptor().decrypt(
+            container: result.container,
+            privateKeyPEM: keyPair.privateKeyPEM,
+        )
+        XCTAssertEqual(decrypted, testPlaintext)
+    }
+
+    private func generateTestECKeyPair() -> (publicKeyPEM: String, privateKeyPEM: String) {
+        let privateKey = P256.KeyAgreement.PrivateKey()
+        return (privateKey.publicKey.pemRepresentation, privateKey.pemRepresentation)
+    }
+
+    func testTDFCBORAlgorithmRoundTrip() throws {
+        let keyPair = generateTestECKeyPair()
+        let policy = try TDFPolicy(json: """
+        {"uuid":"test-policy","body":{"dataAttributes":[],"dissem":[]}}
+        """.data(using: .utf8)!)
+
+        let result = try TDFCBORBuilder()
+            .kasURL(URL(string: "http://localhost:8080/kas")!)
+            .kasPublicKey(keyPair.publicKeyPEM)
+            .policy(policy)
+            .encrypt(plaintext: testPlaintext)
+
+        let serialized = try result.container.serializedData()
+        let loaded = try TDFCBORLoader().load(from: serialized)
+
+        XCTAssertEqual(loaded.manifest.encryptionInformation.method.algorithm, "AES-256-GCM")
+    }
+
+    func testTDFCBORKeyAccessTypeRoundTrip() throws {
+        let keyPair = generateTestECKeyPair()
+        let policy = try TDFPolicy(json: """
+        {"uuid":"test-policy","body":{"dataAttributes":[],"dissem":[]}}
+        """.data(using: .utf8)!)
+
+        let result = try TDFCBORBuilder()
+            .kasURL(URL(string: "http://localhost:8080/kas")!)
+            .kasPublicKey(keyPair.publicKeyPEM)
+            .policy(policy)
+            .encrypt(plaintext: testPlaintext)
+
+        let serialized = try result.container.serializedData()
+        let loaded = try TDFCBORLoader().load(from: serialized)
+
+        let accessType = try XCTUnwrap(loaded.manifest.encryptionInformation.keyAccess.first?.type)
+        XCTAssertEqual(accessType, .ecWrapped)
+    }
 }


### PR DESCRIPTION
This PR addresses the bugs found in the recent codebase audit and removes v13 NanoTDF support.

## Highlights
- Remove v13 NanoTDF creation; all NanoTDFs now use v12 (L1L) headers and v12 HKDF salt.
- Fix NanoTDF Collection nonce padding to match the spec (`[IV][zeros]`).
- Fix `KASRewrapClient` sending an empty `clientPublicKey` by converting the compressed EC point to PEM.
- Fix TDF-JSON/CBOR encrypt/decrypt mismatch: EC wrap now pairs with EC unwrap and sets `keyAccess.type = .ecWrapped`.
- Fix TDF-CBOR algorithm and key-access-type fidelity.
- Fix `KASService.rewrapKey` endpoint path (`/kas/v2/rewrap`).
- Reject zero-length embedded policy bodies in `BinaryParser`.
- Use constant-time comparison for policy binding verification.
- Use `SecRandomCopyBytes` for nonce/key generation and check return status.
- Remove stray `print(...)` statements from library code.

## Verification
- `swift test`: 216 tests, 0 failures
- `swiftformat --lint --swiftversion 6.2 .`: 0 files require formatting

## Branch
`bugfix/audit-fixes`