### PR TITLE
fix(kas): well-known missing kas → default KAS URL + Stage-1 xtest CI

### DIFF
--- a/.github/workflows/xtest-stage1.yml
+++ b/.github/workflows/xtest-stage1.yml
@@ -1,0 +1,318 @@
+# Stage-1 community cross-test: OpenTDFKit (this repo) ↔ go peer via opentdf-tests.
+#
+# Pulls a floating latest *release* of arkavo-org/opentdf-tests (falls back to
+# the community-xtest-stage1 branch until a release exists). Runs native macOS
+# platform deps (Postgres + Keycloak + platform) and pytest -m stage1 for
+# swift × go Base TDF only.
+#
+# Cross-repo: opentdf-tests community-xtest.yml pins OpenTDFKit floating latest
+# the other direction. Coordinate release tags when Stage-1 is green.
+name: X-Test Stage-1
+
+on:
+  pull_request:
+    paths:
+      - "OpenTDFKit/**"
+      - "OpenTDFKitCLI/**"
+      - "OpenTDFKitTests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "xtest/**"
+      - ".github/workflows/xtest-stage1.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tests-ref:
+        required: false
+        type: string
+        default: latest
+        description: >-
+          arkavo-org/opentdf-tests ref: 'latest' (floating GitHub release),
+          branch, tag, or SHA. Falls back to community-xtest-stage1 when no
+          release exists.
+      platform-ref:
+        required: false
+        type: string
+        default: latest
+        description: "opentdf/platform ref: 'latest'/'lts', branch, tag, or SHA"
+      otdfctl-ref:
+        required: false
+        type: string
+        default: latest
+        description: "go/otdfctl peer ref: 'latest'/'lts', branch, tag, or SHA"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-refs:
+    name: Resolve floating pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      tests-ref: ${{ steps.resolve.outputs.tests-ref }}
+      platform-ref: ${{ steps.resolve.outputs.platform-ref }}
+      platform-tag: ${{ steps.resolve.outputs.platform-tag }}
+      go-ref: ${{ steps.resolve.outputs.go-ref }}
+      go-channel: ${{ steps.resolve.outputs.go-channel }}
+    env:
+      TESTS_REF_IN: ${{ inputs.tests-ref || 'latest' }}
+      PLATFORM_REF_IN: ${{ inputs.platform-ref || 'latest' }}
+      OTDFCTL_REF_IN: ${{ inputs.otdfctl-ref || 'latest' }}
+      GH_TOKEN: ${{ github.token }}
+      # Until arkavo-org/opentdf-tests ships a GitHub Release, latest falls back here.
+      TESTS_FALLBACK_REF: community-xtest-stage1
+    steps:
+      - name: Resolve pins
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          resolve_tests() {
+            local input="$1"
+            if [[ "$input" != "latest" ]]; then
+              echo "$input"
+              return 0
+            fi
+            local tag=""
+            if tag=$(gh api "repos/arkavo-org/opentdf-tests/releases/latest" --jq .tag_name 2>/dev/null); then
+              if [[ -n "$tag" && "$tag" != "null" ]]; then
+                echo "$tag"
+                return 0
+              fi
+            fi
+            echo "No opentdf-tests release found; using fallback ${TESTS_FALLBACK_REF}" >&2
+            echo "${TESTS_FALLBACK_REF}"
+          }
+
+          # platform/go latest via git tags (service/* and otdfctl/*).
+          resolve_platform_latest() {
+            git ls-remote --tags --refs https://github.com/opentdf/platform.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^service/v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1V -k2,2V -k3,3V \
+              | tail -1
+          }
+          resolve_otdfctl_latest() {
+            git ls-remote --tags --refs https://github.com/opentdf/platform.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^otdfctl/v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1V -k2,2V -k3,3V \
+              | tail -1
+          }
+
+          TESTS_REF=$(resolve_tests "$TESTS_REF_IN")
+
+          if [[ "$PLATFORM_REF_IN" == "latest" || "$PLATFORM_REF_IN" == "lts" ]]; then
+            PLATFORM_REF=$(resolve_platform_latest)
+            PLATFORM_TAG=latest
+            [[ -n "$PLATFORM_REF" ]] || { echo "failed to resolve platform latest" >&2; exit 1; }
+          else
+            PLATFORM_REF="$PLATFORM_REF_IN"
+            PLATFORM_TAG="$PLATFORM_REF_IN"
+          fi
+
+          if [[ "$OTDFCTL_REF_IN" == "latest" || "$OTDFCTL_REF_IN" == "lts" ]]; then
+            GO_REF=$(resolve_otdfctl_latest)
+            GO_CHANNEL="${GO_REF#otdfctl/}"
+            [[ -n "$GO_REF" ]] || { echo "failed to resolve otdfctl latest" >&2; exit 1; }
+          else
+            GO_REF="$OTDFCTL_REF_IN"
+            GO_CHANNEL="$OTDFCTL_REF_IN"
+          fi
+
+          {
+            echo "tests-ref=${TESTS_REF}"
+            echo "platform-ref=${PLATFORM_REF}"
+            echo "platform-tag=${PLATFORM_TAG}"
+            echo "go-ref=${GO_REF}"
+            echo "go-channel=${GO_CHANNEL}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Resolved pins"
+            echo ""
+            echo "| Component | Input | Resolved |"
+            echo "|---|---|---|"
+            echo "| opentdf-tests | \`${TESTS_REF_IN}\` | \`${TESTS_REF}\` |"
+            echo "| platform | \`${PLATFORM_REF_IN}\` | \`${PLATFORM_REF}\` |"
+            echo "| go/otdfctl | \`${OTDFCTL_REF_IN}\` | \`${GO_REF}\` (channel \`${GO_CHANNEL}\`) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "tests=${TESTS_REF} platform=${PLATFORM_REF} go=${GO_REF}"
+
+  stage1-swift:
+    name: "swift ↔ go stage1"
+    needs: [resolve-refs]
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+    env:
+      TESTS_REF: ${{ needs.resolve-refs.outputs.tests-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+    steps:
+      - name: Checkout OpenTDFKit
+        uses: actions/checkout@v4
+        with:
+          path: OpenTDFKit
+          persist-credentials: false
+
+      - name: Checkout opentdf-tests
+        uses: actions/checkout@v4
+        with:
+          repository: arkavo-org/opentdf-tests
+          ref: ${{ env.TESTS_REF }}
+          path: otdftests
+          persist-credentials: false
+
+      - name: Wire this OpenTDFKit into xtest sdk/swift
+        run: |
+          set -euo pipefail
+          mkdir -p otdftests/xtest/sdk/swift/src
+          # Use the PR/commit under test, not a released OpenTDFKit pin.
+          rm -rf otdftests/xtest/sdk/swift/src/main
+          ln -s "$(pwd)/OpenTDFKit" otdftests/xtest/sdk/swift/src/main
+          ls -la otdftests/xtest/sdk/swift/src/main/Package.swift
+
+      - name: Load extra keys
+        id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - name: Start platform (native macOS)
+        id: run-platform
+        uses: ./otdftests/.github/actions/start-up-with-containers-macos
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+
+      - name: Capture platform otdfctl location
+        id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - name: Resolve go peer
+        id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+          echo "$INFO" | jq .
+
+      - name: Configure otdfctl (go)
+        id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - name: Build go CLI (head builds only)
+        if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - name: Build swift CLI from this checkout
+        run: make VERSIONS=main
+        working-directory: otdftests/xtest/sdk/swift
+
+      - name: Probe swift supports
+        working-directory: otdftests/xtest
+        run: |-
+          set -e
+          ./sdk/swift/dist/main/cli.sh supports tdf || ./sdk/swift/dist/main/cli.sh supports ztdf
+          ./sdk/swift/dist/main/cli.sh supports hexless
+          ! ./sdk/swift/dist/main/cli.sh supports ecwrap || exit 1
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-1 (swift × go, Base TDF)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          set -euo pipefail
+          mkdir -p test-results
+          GO_CH="${GO_CHANNEL}"
+          # go dist may be under tag (release install) or main (head). Prefer
+          # the channel from resolve-refs; fall back to whatever exists.
+          if [[ ! -x "sdk/go/dist/${GO_CH}/cli.sh" ]]; then
+            if [[ -x sdk/go/dist/main/cli.sh ]]; then
+              GO_CH=main
+            else
+              GO_CH=$(find sdk/go/dist -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | head -1)
+            fi
+          fi
+          echo "Using go channel: ${GO_CH}"
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/opentdfkit-stage1.html \
+            --self-contained-html \
+            --junitxml=test-results/opentdfkit-stage1.junit.xml \
+            --sdks-encrypt "swift@main go@${GO_CH}" \
+            --sdks-decrypt "swift@main go@${GO_CH}" \
+            --containers tdf \
+            --focus swift \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py \
+            | tee test-results/opentdfkit-stage1.log
+
+      - name: Upload results
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} opentdfkit-stage1
+          path: otdftests/xtest/test-results/**
+
+      - name: Upload platform logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: opentdfkit-stage1-platform-logs
+          path: ${{ steps.run-platform.outputs.platform-log-file }}
+          if-no-files-found: ignore

--- a/.github/workflows/xtest-stage1.yml
+++ b/.github/workflows/xtest-stage1.yml
@@ -28,9 +28,8 @@ on:
         type: string
         default: latest
         description: >-
-          arkavo-org/opentdf-tests ref: 'latest' (floating GitHub release),
-          branch, tag, or SHA. Falls back to community-xtest-stage1 when no
-          release exists.
+          arkavo-org/opentdf-tests ref: 'latest' (tracks community-xtest-stage1
+          branch tip while Stage-1 is in flux), branch, tag, or SHA.
       platform-ref:
         required: false
         type: string
@@ -67,7 +66,8 @@ jobs:
       PLATFORM_REF_IN: ${{ inputs.platform-ref || 'latest' }}
       OTDFCTL_REF_IN: ${{ inputs.otdfctl-ref || 'latest' }}
       GH_TOKEN: ${{ github.token }}
-      # Until arkavo-org/opentdf-tests ships a GitHub Release, latest falls back here.
+      # Prefer the live Stage-1 branch while the suite is still iterating; float
+      # on GitHub Releases when tests-ref is an explicit release tag.
       TESTS_FALLBACK_REF: community-xtest-stage1
     steps:
       - name: Resolve pins
@@ -81,14 +81,10 @@ jobs:
               echo "$input"
               return 0
             fi
-            local tag=""
-            if tag=$(gh api "repos/arkavo-org/opentdf-tests/releases/latest" --jq .tag_name 2>/dev/null); then
-              if [[ -n "$tag" && "$tag" != "null" ]]; then
-                echo "$tag"
-                return 0
-              fi
-            fi
-            echo "No opentdf-tests release found; using fallback ${TESTS_FALLBACK_REF}" >&2
+            # Stage-1 suite is still moving quickly on the branch. Prefer the
+            # branch tip over a stale "latest" release so SDK PRs pick up
+            # infra fixes (Keycloak host alignment, etc.) without a re-tag.
+            echo "Using live branch ${TESTS_FALLBACK_REF} for floating latest" >&2
             echo "${TESTS_FALLBACK_REF}"
           }
 

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -1,13 +1,12 @@
-# Stage-1 community cross-test: OpenTDFKit (this repo) ↔ go peer via opentdf-tests.
+# Community cross-test: OpenTDFKit (this repo) ↔ go peer via opentdf-tests.
 #
-# Pulls a floating latest *release* of arkavo-org/opentdf-tests (falls back to
-# the community-xtest-stage1 branch until a release exists). Runs native macOS
-# platform deps (Postgres + Keycloak + platform) and pytest -m stage1 for
-# swift × go Base TDF only.
+# Pulls arkavo-org/opentdf-tests (default: community-xtest-stage1 branch tip).
+# Runs native macOS platform deps (Postgres + Keycloak + platform) and pytest
+# for swift × go Base TDF only.
 #
-# Cross-repo: opentdf-tests community-xtest.yml pins OpenTDFKit floating latest
-# the other direction. Coordinate release tags when Stage-1 is green.
-name: X-Test Stage-1
+# Cross-repo: opentdf-tests community-xtest.yml exercises OpenTDFKit the other
+# direction.
+name: X-Test
 
 on:
   pull_request:
@@ -18,7 +17,7 @@ on:
       - "Package.swift"
       - "Package.resolved"
       - "xtest/**"
-      - ".github/workflows/xtest-stage1.yml"
+      - ".github/workflows/xtest.yml"
   push:
     branches: [main]
   workflow_dispatch:
@@ -29,7 +28,7 @@ on:
         default: latest
         description: >-
           arkavo-org/opentdf-tests ref: 'latest' (tracks community-xtest-stage1
-          branch tip while Stage-1 is in flux), branch, tag, or SHA.
+          branch tip), branch, tag, or SHA.
       platform-ref:
         required: false
         type: string
@@ -66,8 +65,7 @@ jobs:
       PLATFORM_REF_IN: ${{ inputs.platform-ref || 'latest' }}
       OTDFCTL_REF_IN: ${{ inputs.otdfctl-ref || 'latest' }}
       GH_TOKEN: ${{ github.token }}
-      # Prefer the live Stage-1 branch while the suite is still iterating; float
-      # on GitHub Releases when tests-ref is an explicit release tag.
+      # Live community branch while the suite is still iterating.
       TESTS_FALLBACK_REF: community-xtest-stage1
     steps:
       - name: Resolve pins
@@ -81,9 +79,8 @@ jobs:
               echo "$input"
               return 0
             fi
-            # Stage-1 suite is still moving quickly on the branch. Prefer the
-            # branch tip over a stale "latest" release so SDK PRs pick up
-            # infra fixes (Keycloak host alignment, etc.) without a re-tag.
+            # Prefer the branch tip over a stale release so SDK PRs pick up
+            # infra fixes without a re-tag.
             echo "Using live branch ${TESTS_FALLBACK_REF} for floating latest" >&2
             echo "${TESTS_FALLBACK_REF}"
           }
@@ -144,8 +141,8 @@ jobs:
 
           echo "tests=${TESTS_REF} platform=${PLATFORM_REF} go=${GO_REF}"
 
-  stage1-swift:
-    name: "swift ↔ go stage1"
+  community-swift:
+    name: "swift ↔ go"
     needs: [resolve-refs]
     runs-on: macos-latest
     timeout-minutes: 90
@@ -264,7 +261,7 @@ jobs:
       - run: uv sync
         working-directory: otdftests/xtest
 
-      - name: Run Stage-1 (swift × go, Base TDF)
+      - name: Run community xtest (swift × go, Base TDF)
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
@@ -286,9 +283,9 @@ jobs:
           fi
           echo "Using go channel: ${GO_CH}"
           uv run pytest -n auto --dist loadscope \
-            --html=test-results/opentdfkit-stage1.html \
+            --html=test-results/opentdfkit-xtest.html \
             --self-contained-html \
-            --junitxml=test-results/opentdfkit-stage1.junit.xml \
+            --junitxml=test-results/opentdfkit-xtest.junit.xml \
             --sdks-encrypt "swift@main go@${GO_CH}" \
             --sdks-decrypt "swift@main go@${GO_CH}" \
             --containers tdf \
@@ -296,19 +293,19 @@ jobs:
             -m stage1 \
             -ra -v \
             test_tdfs.py \
-            | tee test-results/opentdfkit-stage1.log
+            | tee test-results/opentdfkit-xtest.log
 
       - name: Upload results
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ job.status == 'success' && '✅' || '❌' }} opentdfkit-stage1
+          name: ${{ job.status == 'success' && '✅' || '❌' }} opentdfkit-xtest
           path: otdftests/xtest/test-results/**
 
       - name: Upload platform logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: opentdfkit-stage1-platform-logs
+          name: opentdfkit-xtest-platform-logs
           path: ${{ steps.run-platform.outputs.platform-log-file }}
           if-no-files-found: ignore

--- a/OpenTDFKit/KASDiscovery.swift
+++ b/OpenTDFKit/KASDiscovery.swift
@@ -66,16 +66,22 @@ public struct OpenTDFConfiguration: Codable, Sendable {
         )
     }
 
-    /// If this document already exposes usable KAS endpoints, return self.
-    /// Otherwise synthesize Connect endpoints for `fallbackBaseURL` while
-    /// preserving any `idp` / `platformIssuer` discovered from well-known.
+    /// If well-known omitted a usable `kas` advertisement, synthesize Connect
+    /// endpoints for `fallbackBaseURL` while preserving any `idp` /
+    /// `platformIssuer`. Returns self unchanged when a `kas` block already
+    /// advertises Connect or REST endpoint URLs.
     ///
     /// Local platforms often serve `/.well-known/opentdf-configuration` with
     /// IdP metadata but no `kas` block; Stage-1 clients must fall back to the
     /// default KAS URL (typically `PLATFORMURL` / stripped `KASURL`) rather
     /// than fail with "missing a 'kas' block".
+    ///
+    /// **Does not** replace a present kas block whose endpoints fail
+    /// validation (SSRF, non-HTTPS, empty host, etc.). Those failures must
+    /// propagate from `KasEndpoints.from` so hostile well-known documents
+    /// cannot be quietly rewritten to a different KAS identity.
     public func withKasFallback(baseURL: String) -> OpenTDFConfiguration {
-        if (try? KasEndpoints.from(self)) != nil {
+        guard needsKasEndpointSynthesis else {
             return self
         }
         let synthesized = OpenTDFConfiguration.forKasConnect(baseURL)
@@ -84,6 +90,17 @@ public struct OpenTDFConfiguration: Codable, Sendable {
             idp: idp,
             platformIssuer: platformIssuer,
         )
+    }
+
+    /// True when well-known has no kas block, an empty kas uri, or advertises
+    /// neither Connect nor REST endpoint pairs. False when endpoint URLs are
+    /// present (even if they would fail later SSRF/scheme validation).
+    var needsKasEndpointSynthesis: Bool {
+        guard let kas else { return true }
+        if kas.uri.isEmpty { return true }
+        let hasConnect = kas.connectRewrapURL != nil && kas.connectPublicKeyURL != nil
+        let hasRest = kas.rewrapURL != nil && kas.publicKeyURL != nil
+        return !hasConnect && !hasRest
     }
 }
 

--- a/OpenTDFKit/KASDiscovery.swift
+++ b/OpenTDFKit/KASDiscovery.swift
@@ -65,6 +65,26 @@ public struct OpenTDFConfiguration: Codable, Sendable {
             platformIssuer: nil,
         )
     }
+
+    /// If this document already exposes usable KAS endpoints, return self.
+    /// Otherwise synthesize Connect endpoints for `fallbackBaseURL` while
+    /// preserving any `idp` / `platformIssuer` discovered from well-known.
+    ///
+    /// Local platforms often serve `/.well-known/opentdf-configuration` with
+    /// IdP metadata but no `kas` block; Stage-1 clients must fall back to the
+    /// default KAS URL (typically `PLATFORMURL` / stripped `KASURL`) rather
+    /// than fail with "missing a 'kas' block".
+    public func withKasFallback(baseURL: String) -> OpenTDFConfiguration {
+        if (try? KasEndpoints.from(self)) != nil {
+            return self
+        }
+        let synthesized = OpenTDFConfiguration.forKasConnect(baseURL)
+        return OpenTDFConfiguration(
+            kas: synthesized.kas,
+            idp: idp,
+            platformIssuer: platformIssuer,
+        )
+    }
 }
 
 public struct KasConfig: Codable, Sendable {

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -302,6 +302,27 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         return Data(hasher.finalize())
     }
 
+    /// Flatten rewrap metadata for deny/fail diagnostics when no `error` string is present.
+    private static func rewrapDenyReason(_ metadata: [String: RewrapMetadataValue]?) -> String? {
+        guard let metadata, !metadata.isEmpty else { return nil }
+        let parts = metadata.keys.sorted().compactMap { key -> String? in
+            guard let value = metadata[key] else { return nil }
+            switch value {
+            case let .string(s): return "\(key)=\(s)"
+            case let .number(n):
+                if n == n.rounded(), abs(n) < 1e15 {
+                    return "\(key)=\(Int64(n))"
+                }
+                return "\(key)=\(n)"
+            case let .bool(b): return "\(key)=\(b)"
+            case let .array(a): return "\(key)=[\(a.count)]"
+            case .object: return "\(key)={…}"
+            case .null: return "\(key)=null"
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "; ")
+    }
+
     // MARK: - KAS Public Key Response
 
     /// Response structure for KAS EC public key endpoint
@@ -487,7 +508,9 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
             }
 
             guard firstResult.status == "permit" else {
-                let reason = firstResult.metadata?["error"]?.stringValue ?? "Access denied by policy"
+                let reason = firstResult.metadata?["error"]?.stringValue
+                    ?? Self.rewrapDenyReason(firstResult.metadata)
+                    ?? "status=\(firstResult.status)"
                 throw KASRewrapError.accessDenied(reason)
             }
 
@@ -618,7 +641,9 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
             for policyEntry in rewrapResponse.responses {
                 for result in policyEntry.results {
                     guard result.status == "permit" else {
-                        let reason = result.metadata?["error"]?.stringValue ?? "Access denied by policy"
+                        let reason = result.metadata?["error"]?.stringValue
+                            ?? Self.rewrapDenyReason(result.metadata)
+                            ?? "status=\(result.status)"
                         throw KASRewrapError.accessDenied(reason)
                     }
 

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -294,7 +294,7 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         }
     }
 
-    /// HKDF salt for Standard TDF (ZTDF) EC session unwrap — matches go SDK `tdfSalt()`:
+    /// HKDF salt for Standard TDF EC session unwrap — matches go SDK `tdfSalt()`:
     /// `SHA256("TDF")`.
     public static var standardTDFSessionSalt: Data {
         var hasher = SHA256()

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -204,7 +204,9 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         let status: String // "permit" or "fail"
         let kasWrappedKey: String?
         let entityWrappedKey: String? // Legacy field
-        let metadata: [String: String]?
+        /// Platform may return string, array, or object metadata values
+        /// (e.g. `X-Required-Obligations` is a string array).
+        let metadata: [String: RewrapMetadataValue]?
     }
 
     /// Response policy entry
@@ -218,8 +220,72 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         let responses: [ResponsePolicyEntry]
         let sessionPublicKey: String?
         let entityWrappedKey: String? // Legacy field at top level
-        let metadata: [String: String]?
+        let metadata: [String: RewrapMetadataValue]?
         let schemaVersion: String?
+    }
+
+    /// Heterogeneous JSON value in KAS rewrap `metadata` maps.
+    public enum RewrapMetadataValue: Codable, Equatable, Sendable {
+        case string(String)
+        case number(Double)
+        case bool(Bool)
+        case array([RewrapMetadataValue])
+        case object([String: RewrapMetadataValue])
+        case null
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() {
+                self = .null
+                return
+            }
+            if let s = try? container.decode(String.self) {
+                self = .string(s)
+                return
+            }
+            if let b = try? container.decode(Bool.self) {
+                self = .bool(b)
+                return
+            }
+            if let n = try? container.decode(Double.self) {
+                self = .number(n)
+                return
+            }
+            if let a = try? container.decode([RewrapMetadataValue].self) {
+                self = .array(a)
+                return
+            }
+            if let o = try? container.decode([String: RewrapMetadataValue].self) {
+                self = .object(o)
+                return
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported rewrap metadata JSON value",
+            )
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case let .string(s): try container.encode(s)
+            case let .number(n): try container.encode(n)
+            case let .bool(b): try container.encode(b)
+            case let .array(a): try container.encode(a)
+            case let .object(o): try container.encode(o)
+            case .null: try container.encodeNil()
+            }
+        }
+
+        /// Scalar string form for error messages; nil for arrays/objects/null.
+        public var stringValue: String? {
+            switch self {
+            case let .string(s): s
+            case let .number(n): String(n)
+            case let .bool(b): String(b)
+            case .array, .object, .null: nil
+            }
+        }
     }
 
     // MARK: - KAS Public Key Response
@@ -407,7 +473,7 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
             }
 
             guard firstResult.status == "permit" else {
-                let reason = firstResult.metadata?["error"] ?? "Access denied by policy"
+                let reason = firstResult.metadata?["error"]?.stringValue ?? "Access denied by policy"
                 throw KASRewrapError.accessDenied(reason)
             }
 
@@ -538,7 +604,7 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
             for policyEntry in rewrapResponse.responses {
                 for result in policyEntry.results {
                     guard result.status == "permit" else {
-                        let reason = result.metadata?["error"] ?? "Access denied by policy"
+                        let reason = result.metadata?["error"]?.stringValue ?? "Access denied by policy"
                         throw KASRewrapError.accessDenied(reason)
                     }
 

--- a/OpenTDFKit/KASRewrapClient.swift
+++ b/OpenTDFKit/KASRewrapClient.swift
@@ -278,14 +278,28 @@ public final class KASRewrapClient: KASRewrapClientProtocol, Sendable {
         }
 
         /// Scalar string form for error messages; nil for arrays/objects/null.
+        /// Integral doubles render without a trailing `.0` (JSON integers decode as Double).
         public var stringValue: String? {
             switch self {
             case let .string(s): s
-            case let .number(n): String(n)
+            case let .number(n):
+                if n == n.rounded(), abs(n) < 1e15 {
+                    String(Int64(n))
+                } else {
+                    String(n)
+                }
             case let .bool(b): String(b)
             case .array, .object, .null: nil
             }
         }
+    }
+
+    /// HKDF salt for Standard TDF (ZTDF) EC session unwrap — matches go SDK `tdfSalt()`:
+    /// `SHA256("TDF")`.
+    public static var standardTDFSessionSalt: Data {
+        var hasher = SHA256()
+        hasher.update(data: Data("TDF".utf8))
+        return Data(hasher.finalize())
     }
 
     // MARK: - KAS Public Key Response

--- a/OpenTDFKit/TDF/StreamingTDFCrypto.swift
+++ b/OpenTDFKit/TDF/StreamingTDFCrypto.swift
@@ -49,16 +49,14 @@ public enum StreamingTDFCrypto {
 
         let totalEncrypted = Int64(encryptedPayload.count)
 
-        let segmentHash = try TDFCrypto.segmentSignatureGMAC(
-            segmentCiphertext: encryptedPayload,
-            symmetricKey: symmetricKey,
-        )
+        // OpenTDF GMAC integrity = last 16 bytes of segment (AES-GCM tag), base64.
+        let segmentHash = try TDFCrypto.segmentHashBase64GMAC(encryptedSegment: encryptedPayload)
 
         let segment = EncryptedSegment(
             segmentIndex: 0,
             plaintextSize: totalPlaintextRead,
             encryptedSize: totalEncrypted,
-            hash: segmentHash.base64EncodedString(),
+            hash: segmentHash,
         )
 
         let result = StreamingEncryptionResult(
@@ -131,16 +129,13 @@ public enum StreamingTDFCrypto {
             let segmentEncryptedSize = Int64(segmentEnd - segmentStart)
 
             let segmentData = encryptedPayload.subdata(in: segmentStart ..< segmentEnd)
-            let segmentHash = try TDFCrypto.segmentSignatureGMAC(
-                segmentCiphertext: segmentData,
-                symmetricKey: symmetricKey,
-            )
+            let segmentHash = try TDFCrypto.segmentHashBase64GMAC(encryptedSegment: segmentData)
 
             let segment = EncryptedSegment(
                 segmentIndex: segmentIndex,
                 plaintextSize: segmentPlaintextSize,
                 encryptedSize: segmentEncryptedSize,
-                hash: segmentHash.base64EncodedString(),
+                hash: segmentHash,
             )
             segments.append(segment)
 
@@ -241,16 +236,14 @@ public enum StreamingTDFCrypto {
 
         let totalEncrypted = Int64(nonceData.count + sealed.ciphertext.count + sealed.tag.count)
 
-        let segmentHash = try TDFCrypto.segmentSignatureGMAC(
-            segmentCiphertext: Data(nonce) + sealed.ciphertext + Data(sealed.tag),
-            symmetricKey: symmetricKey,
-        )
+        let segmentPayload = Data(nonce) + sealed.ciphertext + Data(sealed.tag)
+        let segmentHash = try TDFCrypto.segmentHashBase64GMAC(encryptedSegment: segmentPayload)
 
         let segment = EncryptedSegment(
             segmentIndex: 0,
             plaintextSize: totalPlaintextRead,
             encryptedSize: totalEncrypted,
-            hash: segmentHash.base64EncodedString(),
+            hash: segmentHash,
         )
 
         return StreamingEncryptionResult(
@@ -317,16 +310,14 @@ public enum StreamingTDFCrypto {
 
             let segmentEncryptedSize = Int64(segmentEndOffset - segmentStartOffset)
 
-            let segmentHash = try TDFCrypto.segmentSignatureGMAC(
-                segmentCiphertext: Data(nonce) + sealed.ciphertext + Data(sealed.tag),
-                symmetricKey: symmetricKey,
-            )
+            let segmentPayload = Data(nonce) + sealed.ciphertext + Data(sealed.tag)
+            let segmentHash = try TDFCrypto.segmentHashBase64GMAC(encryptedSegment: segmentPayload)
 
             let segment = EncryptedSegment(
                 segmentIndex: segmentIndex,
                 plaintextSize: segmentPlaintextSize,
                 encryptedSize: segmentEncryptedSize,
-                hash: segmentHash.base64EncodedString(),
+                hash: segmentHash,
             )
             segments.append(segment)
 

--- a/OpenTDFKit/TDF/TDFCBORContainer.swift
+++ b/OpenTDFKit/TDF/TDFCBORContainer.swift
@@ -136,13 +136,8 @@ public struct TDFCBORBuilder: Sendable {
             symmetricKey: symmetricKey,
         )
 
-        // Calculate segment signature (GMAC)
-        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(
-            segmentCiphertext: payloadData,
-            symmetricKey: symmetricKey,
-        )
-
-        // Calculate root signature
+        // OpenTDF GMAC = AES-GCM tag (last 16 bytes of encrypted segment)
+        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(encryptedSegment: payloadData)
         let rootSignature = TDFCrypto.segmentSignature(
             segmentCiphertext: segmentSignature,
             symmetricKey: symmetricKey,

--- a/OpenTDFKit/TDF/TDFCrypto.swift
+++ b/OpenTDFKit/TDF/TDFCrypto.swift
@@ -195,6 +195,12 @@ public enum TDFCrypto {
         return Data(sealed.tag)
     }
 
+    /// Wrap the payload DEK with the KAS RSA public key.
+    ///
+    /// Uses RSA-OAEP with **SHA-1** to match the OpenTDF platform / go SDK
+    /// (`rsa.EncryptOAEP(sha1.New(), …)`). SHA-256 OAEP is not interoperable
+    /// with current KAS unwrap and surfaces as rewrap failures ("access denied"
+    /// / "bad request" after DEK decrypt fails).
     public static func wrapSymmetricKeyWithRSA(publicKeyPEM: String, symmetricKey: SymmetricKey) throws -> String {
         let keyData = symmetricKey.withUnsafeBytes { rawBuffer -> Data in
             Data(rawBuffer)
@@ -203,7 +209,7 @@ public enum TDFCrypto {
         var error: Unmanaged<CFError>?
         guard let encrypted = SecKeyCreateEncryptedData(
             publicKey,
-            .rsaEncryptionOAEPSHA256,
+            .rsaEncryptionOAEPSHA1,
             keyData as CFData,
             &error,
         ) as Data? else {
@@ -212,6 +218,7 @@ public enum TDFCrypto {
         return encrypted.base64EncodedString()
     }
 
+    /// Unwrap a KAS RSA-wrapped DEK (OAEP-SHA1, matching go platform).
     public static func unwrapSymmetricKeyWithRSA(privateKeyPEM: String, wrappedKey: String) throws -> SymmetricKey {
         let privateKey = try loadRSAPrivateKey(fromPEM: privateKeyPEM)
         guard let wrappedData = Data(base64Encoded: wrappedKey) else {
@@ -220,7 +227,7 @@ public enum TDFCrypto {
         var error: Unmanaged<CFError>?
         guard var decrypted = SecKeyCreateDecryptedData(
             privateKey,
-            .rsaEncryptionOAEPSHA256,
+            .rsaEncryptionOAEPSHA1,
             wrappedData as CFData,
             &error,
         ) as Data? else {

--- a/OpenTDFKit/TDF/TDFCrypto.swift
+++ b/OpenTDFKit/TDF/TDFCrypto.swift
@@ -162,9 +162,21 @@ public enum TDFCrypto {
         return Data(plaintext)
     }
 
+    /// Compute the Standard TDF policy binding hash (OpenTDF / go SDK format).
+    ///
+    /// 1. Base64-encode the raw policy JSON bytes
+    /// 2. HMAC-SHA256 the base64 string as UTF-8 using the payload DEK
+    /// 3. Hex-encode the 32-byte HMAC (64 lowercase hex chars)
+    /// 4. Base64-encode that hex string for the manifest `policyBinding.hash`
+    ///
+    /// Using raw HMAC base64 (previous behavior) fails KAS rewrap with
+    /// "tamper detected" when go/java decrypt a Swift-produced TDF.
     public static func policyBinding(policy: Data, symmetricKey: SymmetricKey) -> TDFPolicyBinding {
-        let hmac = HMAC<SHA256>.authenticationCode(for: policy, using: symmetricKey)
-        let hash = Data(hmac).base64EncodedString()
+        let policyBase64 = policy.base64EncodedString()
+        let policyBase64Bytes = Data(policyBase64.utf8)
+        let hmac = HMAC<SHA256>.authenticationCode(for: policyBase64Bytes, using: symmetricKey)
+        let hex = Data(hmac).map { String(format: "%02x", $0) }.joined()
+        let hash = Data(hex.utf8).base64EncodedString()
         return TDFPolicyBinding(alg: "HS256", hash: hash)
     }
 

--- a/OpenTDFKit/TDF/TDFCrypto.swift
+++ b/OpenTDFKit/TDF/TDFCrypto.swift
@@ -184,15 +184,48 @@ public enum TDFCrypto {
         symmetricKey.withUnsafeBytes { Data($0) }
     }
 
+    /// HS256 root/segment signature: raw HMAC-SHA256 digest (32 bytes).
     public static func segmentSignature(segmentCiphertext: Data, symmetricKey: SymmetricKey) -> Data {
         let hmac = HMAC<SHA256>.authenticationCode(for: segmentCiphertext, using: symmetricKey)
         return Data(hmac)
     }
 
-    public static func segmentSignatureGMAC(segmentCiphertext: Data, symmetricKey: SymmetricKey) throws -> Data {
-        let nonce = try AES.GCM.Nonce(data: Data(count: 12))
-        let sealed = try AES.GCM.seal(Data(), using: symmetricKey, nonce: nonce, authenticating: segmentCiphertext)
-        return Data(sealed.tag)
+    /// OpenTDF "GMAC" segment integrity for AES-GCM payloads is **not** a separate
+    /// MAC — it is the last 16 bytes of the encrypted segment (the AES-GCM tag).
+    /// Matches go SDK `calculateSignature` with GMAC + hexless (4.3.0).
+    ///
+    /// - Parameter encryptedSegment: IV (12) + ciphertext + tag (16)
+    /// - Returns: 16-byte GCM tag
+    public static func segmentSignatureGMAC(encryptedSegment: Data) throws -> Data {
+        let tagSize = 16
+        guard encryptedSegment.count >= tagSize else {
+            throw TDFCryptoError.decryptionFailed(
+                "Encrypted segment too short for GMAC (\(encryptedSegment.count) < \(tagSize))",
+            )
+        }
+        return Data(encryptedSegment.suffix(tagSize))
+    }
+
+    /// Manifest segment hash string for hexless TDF 4.3.0: `base64(raw GMAC/tag)`.
+    public static func segmentHashBase64GMAC(encryptedSegment: Data) throws -> String {
+        try segmentSignatureGMAC(encryptedSegment: encryptedSegment).base64EncodedString()
+    }
+
+    /// Root signature for hexless TDF 4.3.0: `base64(HMAC-SHA256(DEK, concat(raw segment sigs)))`.
+    public static func rootSignatureBase64(
+        rawSegmentSignatures: [Data],
+        symmetricKey: SymmetricKey,
+    ) -> String {
+        let aggregate = rawSegmentSignatures.reduce(into: Data()) { $0.append($1) }
+        let hmac = HMAC<SHA256>.authenticationCode(for: aggregate, using: symmetricKey)
+        return Data(hmac).base64EncodedString()
+    }
+
+    /// Legacy helper kept for call sites that previously computed a synthetic GMAC.
+    /// Prefer `segmentSignatureGMAC(encryptedSegment:)` for OpenTDF interop.
+    @available(*, deprecated, message: "Use segmentSignatureGMAC(encryptedSegment:) — OpenTDF GMAC is the AES-GCM tag")
+    public static func segmentSignatureGMAC(segmentCiphertext: Data, symmetricKey _: SymmetricKey) throws -> Data {
+        try segmentSignatureGMAC(encryptedSegment: segmentCiphertext)
     }
 
     /// Wrap the payload DEK with the KAS RSA public key.

--- a/OpenTDFKit/TDF/TDFJSONContainer.swift
+++ b/OpenTDFKit/TDF/TDFJSONContainer.swift
@@ -135,13 +135,8 @@ public struct TDFJSONBuilder: Sendable {
             symmetricKey: symmetricKey,
         )
 
-        // Calculate segment signature (GMAC)
-        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(
-            segmentCiphertext: payloadData,
-            symmetricKey: symmetricKey,
-        )
-
-        // Calculate root signature
+        // OpenTDF GMAC = AES-GCM tag (last 16 bytes of encrypted segment)
+        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(encryptedSegment: payloadData)
         let rootSignature = TDFCrypto.segmentSignature(
             segmentCiphertext: segmentSignature,
             symmetricKey: symmetricKey,

--- a/OpenTDFKit/TDF/TDFProcessor.swift
+++ b/OpenTDFKit/TDF/TDFProcessor.swift
@@ -126,11 +126,12 @@ public struct TDFEncryptor {
             )
         }
 
-        let segmentSignatureBase64 = segments.first!.hash
-        let rootSignature = TDFCrypto.segmentSignature(
-            segmentCiphertext: Data(base64Encoded: segmentSignatureBase64)!,
+        // Hexless 4.3.0: root = base64(HMAC-SHA256(DEK, concat(raw GMAC tags))).
+        let rawSegmentSigs = segments.compactMap { Data(base64Encoded: $0.hash) }
+        let rootSignature = TDFCrypto.rootSignatureBase64(
+            rawSegmentSignatures: rawSegmentSigs,
             symmetricKey: symmetricKey,
-        ).base64EncodedString()
+        )
 
         let integrity = TDFIntegrityInformation(
             rootSignature: TDFRootSignature(alg: "HS256", sig: rootSignature),
@@ -237,12 +238,11 @@ public struct TDFEncryptor {
             )
         }
 
-        let segmentHashes = segments.map { Data(base64Encoded: $0.hash)! }
-        let concatenatedHashes = segmentHashes.reduce(Data(), +)
-        let rootSignature = TDFCrypto.segmentSignature(
-            segmentCiphertext: concatenatedHashes,
+        let rawSegmentSigs = segments.compactMap { Data(base64Encoded: $0.hash) }
+        let rootSignature = TDFCrypto.rootSignatureBase64(
+            rawSegmentSignatures: rawSegmentSigs,
             symmetricKey: symmetricKey,
-        ).base64EncodedString()
+        )
 
         let defaultSegmentSize = segmentSizes.first ?? StreamingTDFCrypto.defaultChunkSize
         let integrity = TDFIntegrityInformation(
@@ -314,10 +314,12 @@ public struct TDFEncryptor {
         let policyBinding = TDFCrypto.policyBinding(policy: configuration.policy.json, symmetricKey: symmetricKey)
         let wrappedKey = try TDFCrypto.wrapSymmetricKeyWithRSA(publicKeyPEM: configuration.kas.publicKeyPEM, symmetricKey: symmetricKey)
 
-        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(segmentCiphertext: payloadData, symmetricKey: symmetricKey)
+        let segmentSignature = try TDFCrypto.segmentSignatureGMAC(encryptedSegment: payloadData)
         let segmentSignatureBase64 = segmentSignature.base64EncodedString()
-
-        let rootSignature = TDFCrypto.segmentSignature(segmentCiphertext: segmentSignature, symmetricKey: symmetricKey).base64EncodedString()
+        let rootSignature = TDFCrypto.rootSignatureBase64(
+            rawSegmentSignatures: [segmentSignature],
+            symmetricKey: symmetricKey,
+        )
 
         let method = TDFMethodDescriptor(
             algorithm: configuration.keySize.algorithm,

--- a/OpenTDFKitCLI/Commands.swift
+++ b/OpenTDFKitCLI/Commands.swift
@@ -492,9 +492,10 @@ enum Commands {
 
     /// Resolve an OpenTDFConfiguration for the platform hosting `kasURL`.
     /// Tries well-known discovery at the platform root (PLATFORMURL env, else
-    /// the scheme/host/port of `kasURL`), falling back to synthesized Connect
-    /// endpoints. The well-known doc and Connect endpoints live at the platform
-    /// root, not under the KAS `/kas` path.
+    /// the scheme/host/port of `kasURL`). If well-known is missing **or**
+    /// present without a usable `kas` block, fall back to synthesized Connect
+    /// endpoints at the default KAS base. Connect paths live at the platform
+    /// root, not under the KAS `/kas` identity path.
     static func resolveConfiguration(kasURL: URL, token _: String) async -> OpenTDFConfiguration {
         let platformBase: String
         if let env = ProcessInfo.processInfo.environment["PLATFORMURL"], !env.isEmpty {
@@ -506,10 +507,39 @@ enum Commands {
             comps.port = kasURL.port
             platformBase = comps.string ?? kasURL.absoluteString
         }
+        let fallbackBase = defaultKasConnectBase(kasURL: kasURL, platformBase: platformBase)
         if let cfg = try? await fetchWellKnown(platformURL: platformBase) {
-            return cfg
+            // Incomplete well-known (e.g. IdP only, no kas) → keep IdP, fill kas.
+            return cfg.withKasFallback(baseURL: fallbackBase)
         }
-        return OpenTDFConfiguration.forKasConnect(platformBase)
+        return OpenTDFConfiguration.forKasConnect(fallbackBase)
+    }
+
+    /// Connect endpoints attach to the platform root. Prefer `PLATFORMURL`,
+    /// then `KASURL`/`TDF_KAS_URL` with a trailing `/kas` stripped, then the
+    /// scheme/host/port derived from the manifest `kasURL`.
+    static func defaultKasConnectBase(kasURL: URL, platformBase: String) -> String {
+        func stripKasPath(_ raw: String) -> String {
+            var s = raw
+            while s.hasSuffix("/") {
+                s.removeLast()
+            }
+            if s.hasSuffix("/kas") {
+                s = String(s.dropLast(4))
+            }
+            while s.hasSuffix("/") {
+                s.removeLast()
+            }
+            return s
+        }
+        let env = ProcessInfo.processInfo.environment
+        if let platform = env["PLATFORMURL"], !platform.isEmpty {
+            return stripKasPath(platform)
+        }
+        if let kas = env["KASURL"] ?? env["TDF_KAS_URL"], !kas.isEmpty {
+            return stripKasPath(kas)
+        }
+        return stripKasPath(platformBase.isEmpty ? kasURL.absoluteString : platformBase)
     }
 
     /// Fetch KAS public key

--- a/OpenTDFKitCLI/Commands.swift
+++ b/OpenTDFKitCLI/Commands.swift
@@ -226,13 +226,17 @@ enum Commands {
     /// 1. `TOKENENDPOINT` env
     /// 2. `KCFULLURL` + `/protocol/openid-connect/token`
     /// 3. `platformURL` + `/token` (local platform convenience)
+    ///
+    /// Loopback hosts are normalized to `127.0.0.1` so the JWT `iss` claim
+    /// matches platform `server.auth.issuer` (CI often sets issuer to
+    /// `http://127.0.0.1:8888/...` while test.env still says `localhost`).
     static func getOAuthToken(
         platformURL: String,
         clientID: String,
         clientSecret: String,
     ) async throws -> String {
         let env = ProcessInfo.processInfo.environment
-        let tokenURLString: String = if let explicit = env["TOKENENDPOINT"], !explicit.isEmpty {
+        let rawTokenURL: String = if let explicit = env["TOKENENDPOINT"], !explicit.isEmpty {
             explicit
         } else if let kc = env["KCFULLURL"], !kc.isEmpty {
             kc.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -240,6 +244,7 @@ enum Commands {
         } else {
             platformURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/token"
         }
+        let tokenURLString = normalizeLoopbackHost(rawTokenURL)
 
         guard let tokenURL = URL(string: tokenURLString) else {
             throw DecryptError.missingOAuthToken
@@ -248,17 +253,20 @@ enum Commands {
         var request = URLRequest(url: tokenURL)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        // application/x-www-form-urlencoded: encode as form fields (not query allow-list).
         let body =
-            "grant_type=client_credentials&client_id=\(urlEncode(clientID))&client_secret=\(urlEncode(clientSecret))"
+            "grant_type=client_credentials&client_id=\(formURLEncode(clientID))&client_secret=\(formURLEncode(clientSecret))"
         request.httpBody = body.data(using: .utf8)
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let detail = String(data: data, encoding: .utf8) ?? ""
             throw NSError(
                 domain: "OpenTDFKitCLI",
                 code: status,
-                userInfo: [NSLocalizedDescriptionKey: "OAuth token request failed (HTTP \(status)) at \(tokenURLString)"],
+                userInfo: [NSLocalizedDescriptionKey:
+                    "OAuth token request failed (HTTP \(status)) at \(tokenURLString): \(detail)"],
             )
         }
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -266,6 +274,24 @@ enum Commands {
             throw DecryptError.missingOAuthToken
         }
         return token
+    }
+
+    /// Rewrite `localhost` → `127.0.0.1` in URLs so OIDC `iss` matches platform issuer.
+    static func normalizeLoopbackHost(_ urlString: String) -> String {
+        var s = urlString
+        s = s.replacingOccurrences(of: "://localhost:", with: "://127.0.0.1:")
+        s = s.replacingOccurrences(of: "://localhost/", with: "://127.0.0.1/")
+        if s.hasSuffix("://localhost") {
+            s = s.replacingOccurrences(of: "://localhost", with: "://127.0.0.1")
+        }
+        return s
+    }
+
+    /// Form-urlencoded encoding for OAuth token POST bodies.
+    private static func formURLEncode(_ value: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
     /// Fetch RSA public key PEM (+ optional kid) from KAS for Standard TDF wrap.
@@ -338,10 +364,6 @@ enum Commands {
             code: 1,
             userInfo: [NSLocalizedDescriptionKey: "Unable to fetch KAS RSA public key via Connect or REST"],
         )
-    }
-
-    private static func urlEncode(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
     }
 
     private static func xorKeyData(_ lhs: Data, _ rhs: Data) -> Data {

--- a/OpenTDFKitCLI/Commands.swift
+++ b/OpenTDFKitCLI/Commands.swift
@@ -1503,27 +1503,10 @@ extension Commands {
             return try TDFPolicy(json: data)
         }
 
-        // XT_WITH_ATTRIBUTES: Stage-1 / xtest attribute FQNs (go attributeObject shape).
-        let attributeObjects: [[String: String]] = (env["XT_WITH_ATTRIBUTES"] ?? "")
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-            .map { ["attribute": $0] }
-
-        let policy: [String: Any] = [
-            "uuid": UUID().uuidString.lowercased(),
-            "body": [
-                "dataAttributes": attributeObjects,
-                "dissem": [] as [Any],
-            ],
-        ]
-
-        guard JSONSerialization.isValidJSONObject(policy),
-              let data = try? JSONSerialization.data(withJSONObject: policy, options: [.sortedKeys])
-        else {
+        do {
+            return try TDFPolicy(json: Config.defaultPolicyData(env: env))
+        } catch {
             throw EncryptError.missingConfiguration("Unable to create default policy")
         }
-
-        return try TDFPolicy(json: data)
     }
 }

--- a/OpenTDFKitCLI/Commands.swift
+++ b/OpenTDFKitCLI/Commands.swift
@@ -176,7 +176,7 @@ enum Commands {
                 clientPrivateKey: ephemeralPrivateKey,
             )
 
-            // Prefer Stage-1 path: EC session unwrap with empty salt (Standard TDF).
+            // Prefer Stage-1 path: EC session unwrap with go `tdfSalt()` = SHA256("TDF").
             if let sessionPEM = result.sessionPublicKeyPEM, !sessionPEM.isEmpty {
                 let (compressedSessionKey, _) = try KASRewrapClient.validateEcPublicKeyPEM(sessionPEM)
                 for (_, wrappedKeyData) in result.wrappedKeys.sorted(by: { $0.key < $1.key }) {
@@ -184,7 +184,7 @@ enum Commands {
                         wrappedKey: wrappedKeyData,
                         sessionPublicKey: compressedSessionKey,
                         clientPrivateKey: ephemeralPrivateKey.rawRepresentation,
-                        salt: Data(), // Standard TDF HKDF salt is empty
+                        salt: KASRewrapClient.standardTDFSessionSalt,
                     )
                     keyShares.append(TDFCrypto.data(from: share))
                 }
@@ -1503,11 +1503,17 @@ extension Commands {
             return try TDFPolicy(json: data)
         }
 
-        // Create default policy
+        // XT_WITH_ATTRIBUTES: Stage-1 / xtest attribute FQNs (go attributeObject shape).
+        let attributeObjects: [[String: String]] = (env["XT_WITH_ATTRIBUTES"] ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .map { ["attribute": $0] }
+
         let policy: [String: Any] = [
             "uuid": UUID().uuidString.lowercased(),
             "body": [
-                "dataAttributes": [] as [Any],
+                "dataAttributes": attributeObjects,
                 "dissem": [] as [Any],
             ],
         ]

--- a/OpenTDFKitCLI/Config.swift
+++ b/OpenTDFKitCLI/Config.swift
@@ -37,16 +37,10 @@ struct Config {
             throw ConfigError.missingRequired("PLATFORMURL")
         }
 
-        // Parse attributes and allowlist from comma-separated strings
-        let attributes = (env["XT_WITH_ATTRIBUTES"] ?? "")
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-
-        let kasAllowlist = (env["XT_WITH_KAS_ALLOWLIST"] ?? env["XT_WITH_KAS_ALLOW_LIST"] ?? "")
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
+        let attributes = parseCommaSeparated(env["XT_WITH_ATTRIBUTES"])
+        let kasAllowlist = parseCommaSeparated(
+            env["XT_WITH_KAS_ALLOWLIST"] ?? env["XT_WITH_KAS_ALLOW_LIST"],
+        )
 
         return Config(
             clientId: clientId,
@@ -66,31 +60,72 @@ struct Config {
             withIgnoreKasAllowlist: env["XT_WITH_IGNORE_KAS_ALLOWLIST"] == "true",
         )
     }
+
+    /// Comma-separated env list → trimmed non-empty tokens.
+    static func parseCommaSeparated(_ raw: String?) -> [String] {
+        (raw ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// `XT_WITH_ATTRIBUTES` FQNs as go SDK `attributeObject` entries: `{"attribute":"<fqn>"}`.
+    static func attributeObjectsFromEnvironment(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+    ) -> [[String: String]] {
+        parseCommaSeparated(env["XT_WITH_ATTRIBUTES"]).map { ["attribute": $0] }
+    }
+
+    /// Default TDF policy JSON body for encrypt when no TDF_POLICY_* override is set.
+    static func defaultPolicyData(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+    ) throws -> Data {
+        let policy: [String: Any] = [
+            "uuid": UUID().uuidString.lowercased(),
+            "body": [
+                "dataAttributes": attributeObjectsFromEnvironment(env: env),
+                "dissem": [] as [Any],
+            ],
+        ]
+        guard JSONSerialization.isValidJSONObject(policy),
+              let data = try? JSONSerialization.data(withJSONObject: policy, options: [.sortedKeys])
+        else {
+            throw ConfigError.invalidPolicy
+        }
+        return data
+    }
 }
 
 enum ConfigError: Error, CustomStringConvertible {
     case missingRequired(String)
+    case invalidPolicy
 
     var description: String {
         switch self {
         case let .missingRequired(name):
             "Required environment variable '\(name)' is not set"
+        case .invalidPolicy:
+            "Unable to create default policy JSON"
         }
     }
 }
 
-/// TDF format types supported by xtest
+/// TDF format types supported by xtest (Base / standard TDF ZIP, not NATO ZTDF).
 enum TDFFormat: String {
     case nano
-    case ztdf
-    case ztdfECWrap = "ztdf-ecwrap"
+    case tdf
+    /// Legacy wire name used by some xtest shims for Base TDF ZIP — treated as `tdf`.
+    case tdfLegacyWire = "ztdf"
+    case tdfECWrap = "tdf-ecwrap"
+    /// Legacy alias for `tdf-ecwrap`.
+    case tdfECWrapLegacy = "ztdf-ecwrap"
     case nanoWithECDSA = "nano-with-ecdsa"
 
     var isNano: Bool {
         switch self {
         case .nano, .nanoWithECDSA:
             true
-        case .ztdf, .ztdfECWrap:
+        case .tdf, .tdfLegacyWire, .tdfECWrap, .tdfECWrapLegacy:
             false
         }
     }
@@ -100,6 +135,15 @@ enum TDFFormat: String {
     }
 
     var useECWrap: Bool {
-        self == .ztdfECWrap
+        self == .tdfECWrap || self == .tdfECWrapLegacy
+    }
+
+    /// Canonical format for CLI dispatch (legacy wire names collapse to Base TDF).
+    var canonical: TDFFormat {
+        switch self {
+        case .tdfLegacyWire: .tdf
+        case .tdfECWrapLegacy: .tdfECWrap
+        default: self
+        }
     }
 }

--- a/OpenTDFKitCLI/main.swift
+++ b/OpenTDFKitCLI/main.swift
@@ -621,11 +621,19 @@ struct OpenTDFKitCLI {
             return data
         }
 
+        // XT_WITH_ATTRIBUTES is the Stage-1 / xtest attribute list (comma-separated FQNs).
+        // Shape matches go SDK attributeObject: {"attribute":"<fqn>"}.
+        let attributeObjects: [[String: String]] = (env["XT_WITH_ATTRIBUTES"] ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .map { ["attribute": $0] }
+
         let policy: [String: Any] = [
             "uuid": UUID().uuidString.lowercased(),
             "body": [
-                "dataAttributes": [],
-                "dissem": [],
+                "dataAttributes": attributeObjects,
+                "dissem": [] as [Any],
             ],
         ]
 

--- a/OpenTDFKitCLI/main.swift
+++ b/OpenTDFKitCLI/main.swift
@@ -9,7 +9,6 @@ enum CLIDataFormat: String {
     case nanoWithECDSA = "nano-with-ecdsa"
     case nanoCollection = "nano-collection"
     case tdf
-    case ztdf
     case json
     case cbor
 
@@ -26,6 +25,10 @@ enum CLIDataFormat: String {
         }
         if normalized == "tdf-cbor" || normalized == "tdfcbor" {
             return .cbor
+        }
+        // Legacy wire name used by some xtest shims for Base TDF ZIP containers.
+        if normalized == "ztdf" {
+            return .tdf
         }
         guard let format = CLIDataFormat(rawValue: normalized) else {
             throw CLIError.unsupportedFormat(rawValue)
@@ -131,8 +134,7 @@ struct OpenTDFKitCLI {
           nano               Standard NanoTDF
           nano-with-ecdsa    NanoTDF with ECDSA binding
           nano-collection    NanoTDF Collection (single key, multiple payloads)
-          tdf                Standard ZIP-based TDF (supports streaming)
-          ztdf               ZTDF alias for standard TDF
+          tdf                Base / standard ZIP-based TDF (supports streaming)
           json               TDF-JSON format (inline base64 payload)
           cbor               TDF-CBOR format (binary payload)
 
@@ -141,7 +143,7 @@ struct OpenTDFKitCLI {
           --segments <sizes>     Comma-separated segment sizes (e.g., 2m,5m,2m)
 
         Features (for supports command):
-          nano, nano_ecdsa, nano_collection, ztdf, json, cbor, etc.
+          nano, nano_ecdsa, nano_collection, tdf, json, cbor, hexless, etc.
 
         Environment Variables:
           CLIENTID           OAuth client ID
@@ -276,7 +278,7 @@ struct OpenTDFKitCLI {
         case .nanoCollection:
             try await Commands.encryptFileToCollection(inputURL: inputURL, outputURL: outputURL)
             return
-        case .tdf, .ztdf:
+        case .tdf:
             let configuration = try await buildTDFConfiguration(for: inputURL)
 
             if let segmentString = segmentsFlag.value {
@@ -372,7 +374,7 @@ struct OpenTDFKitCLI {
         case .nanoCollection:
             try await Commands.decryptCollectionToFile(inputURL: inputURL, outputURL: outputURL)
             return
-        case .tdf, .ztdf:
+        case .tdf:
             let symmetricKey = try loadSymmetricKeyFromEnvironment()
             let privateKey = try loadPrivateKeyPEMFromEnvironment()
             var oauthToken: String? = nil
@@ -454,7 +456,7 @@ struct OpenTDFKitCLI {
             throw CLIError.fileNotFound(inputURL.path)
         }
 
-        guard format == .tdf || format == .ztdf else {
+        guard format == .tdf else {
             throw CLIError.notYetSupported("Benchmark only supports TDF format currently")
         }
 
@@ -621,29 +623,11 @@ struct OpenTDFKitCLI {
             return data
         }
 
-        // XT_WITH_ATTRIBUTES is the Stage-1 / xtest attribute list (comma-separated FQNs).
-        // Shape matches go SDK attributeObject: {"attribute":"<fqn>"}.
-        let attributeObjects: [[String: String]] = (env["XT_WITH_ATTRIBUTES"] ?? "")
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-            .map { ["attribute": $0] }
-
-        let policy: [String: Any] = [
-            "uuid": UUID().uuidString.lowercased(),
-            "body": [
-                "dataAttributes": attributeObjects,
-                "dissem": [] as [Any],
-            ],
-        ]
-
-        guard JSONSerialization.isValidJSONObject(policy),
-              let data = try? JSONSerialization.data(withJSONObject: policy, options: [.sortedKeys])
-        else {
+        do {
+            return try Config.defaultPolicyData(env: env)
+        } catch {
             throw CLIError.invalidPolicy
         }
-
-        return data
     }
 
     private static func loadPEMString(valueKey: String, pathKey: String) throws -> String {
@@ -744,13 +728,14 @@ struct OpenTDFKitCLI {
 
         let feature = args[2]
 
-        // Official xtest feature_type catalog: advertise only proven Stage-1 basics.
+        // Official xtest feature_type catalog: advertise only proven basics.
         // Formats are not official feature_type probes; keep format names for local tooling.
         switch feature {
         case "nano", "nano_ecdsa", "nano_collection":
             return 0
         case "tdf", "ztdf":
-            // Stage-1 KAS path: OAuth + RSA wrap encrypt + ephemeral rewrap decrypt
+            // Base TDF ZIP: OAuth + RSA wrap encrypt + ephemeral rewrap decrypt.
+            // "ztdf" remains accepted as a legacy wire alias only (not NATO ZTDF).
             return 0
         case "json", "tdf-json", "tdfjson", "cbor", "tdf-cbor", "tdfcbor":
             return 0
@@ -759,7 +744,7 @@ struct OpenTDFKitCLI {
             return 0
         case "connectrpc":
             return 0
-        case "ztdf-ecwrap", "assertions", "assertion_verification",
+        case "tdf-ecwrap", "ztdf-ecwrap", "assertions", "assertion_verification",
              "attribute_traversal", "audit_logging", "autoconfigure",
              "better-messages-2024", "bulk_rewrap", "dpop", "dpop_nonce_challenge",
              "ecwrap", "hexaflexible", "kasallowlist", "key_management",

--- a/OpenTDFKitTests/KASDiscoveryTests.swift
+++ b/OpenTDFKitTests/KASDiscoveryTests.swift
@@ -132,6 +132,55 @@ final class KASDiscoveryTests: XCTestCase {
         XCTAssertThrowsError(try KasEndpoints.from(cfg))
     }
 
+    func testWithKasFallbackSynthesizesWhenKasMissing() throws {
+        // Platform well-known often has IdP metadata without a kas block.
+        let incomplete = OpenTDFConfiguration(
+            kas: nil,
+            idp: nil,
+            platformIssuer: "http://localhost:8888/auth/realms/opentdf",
+        )
+        XCTAssertThrowsError(try KasEndpoints.from(incomplete))
+
+        let filled = incomplete.withKasFallback(baseURL: "http://localhost:8080")
+        let ep = try KasEndpoints.from(filled)
+        XCTAssertEqual(ep.transport, .connect)
+        XCTAssertEqual(ep.rewrapURL, "http://localhost:8080/kas.AccessService/Rewrap")
+        XCTAssertEqual(ep.publicKeyURL, "http://localhost:8080/kas.AccessService/PublicKey")
+        XCTAssertEqual(filled.kas?.uri, "http://localhost:8080")
+        XCTAssertEqual(filled.platformIssuer, "http://localhost:8888/auth/realms/opentdf")
+    }
+
+    func testWithKasFallbackPreservesUsableWellKnown() throws {
+        let cfg = try JSONDecoder().decode(
+            OpenTDFConfiguration.self,
+            from: Data(Self.platformWellKnown.utf8),
+        )
+        let filled = cfg.withKasFallback(baseURL: "http://localhost:8080")
+        // Must keep the well-known Connect endpoints, not the fallback base.
+        let ep = try KasEndpoints.from(filled)
+        XCTAssertEqual(ep.rewrapURL, "https://platform.arkavo.net/kas.AccessService/Rewrap")
+        XCTAssertEqual(filled.kas?.uri, "https://platform.arkavo.net")
+    }
+
+    func testWithKasFallbackWhenKasHasNoEndpoints() throws {
+        let incomplete = OpenTDFConfiguration(
+            kas: KasConfig(
+                uri: "http://localhost:8080",
+                algorithms: [],
+                publicKeyURL: nil,
+                rewrapURL: nil,
+                connectPublicKeyURL: nil,
+                connectRewrapURL: nil,
+            ),
+            idp: nil,
+            platformIssuer: nil,
+        )
+        let filled = incomplete.withKasFallback(baseURL: "http://localhost:8080")
+        let ep = try KasEndpoints.from(filled)
+        XCTAssertEqual(ep.transport, .connect)
+        XCTAssertEqual(ep.rewrapURL, "http://localhost:8080/kas.AccessService/Rewrap")
+    }
+
     func testFromConfigThrowsWhenUriEmpty() {
         let cfg = OpenTDFConfiguration(
             kas: KasConfig(uri: "", algorithms: [],

--- a/OpenTDFKitTests/KASDiscoveryTests.swift
+++ b/OpenTDFKitTests/KASDiscoveryTests.swift
@@ -181,6 +181,50 @@ final class KASDiscoveryTests: XCTestCase {
         XCTAssertEqual(ep.rewrapURL, "http://localhost:8080/kas.AccessService/Rewrap")
     }
 
+    func testWithKasFallbackDoesNotReplaceHostileKasEndpoints() {
+        // Present kas block with SSRF-bait rewrap URL must not be rewritten to
+        // fallbackBase — validation must fail at KasEndpoints.from instead.
+        let hostile = OpenTDFConfiguration(
+            kas: KasConfig(
+                uri: "https://platform.example.com",
+                algorithms: [],
+                publicKeyURL: nil,
+                rewrapURL: nil,
+                connectPublicKeyURL: "https://platform.example.com/kas.AccessService/PublicKey",
+                connectRewrapURL: "https://169.254.169.254/kas.AccessService/Rewrap",
+            ),
+            idp: nil,
+            platformIssuer: nil,
+        )
+        let after = hostile.withKasFallback(baseURL: "http://localhost:8080")
+        XCTAssertEqual(after.kas?.connectRewrapURL, "https://169.254.169.254/kas.AccessService/Rewrap")
+        XCTAssertEqual(after.kas?.uri, "https://platform.example.com")
+        XCTAssertThrowsError(try KasEndpoints.from(after)) { error in
+            guard case KASDiscoveryError.invalidURL = error else {
+                return XCTFail("expected invalidURL (SSRF), got \(error)")
+            }
+        }
+    }
+
+    func testWithKasFallbackWhenUriEmpty() throws {
+        let emptyUri = OpenTDFConfiguration(
+            kas: KasConfig(
+                uri: "",
+                algorithms: [],
+                publicKeyURL: "https://k.example.com/kas/v2/kas_public_key",
+                rewrapURL: "https://k.example.com/kas/v2/rewrap",
+                connectPublicKeyURL: nil,
+                connectRewrapURL: nil,
+            ),
+            idp: nil,
+            platformIssuer: nil,
+        )
+        let filled = emptyUri.withKasFallback(baseURL: "http://localhost:8080")
+        XCTAssertEqual(filled.kas?.uri, "http://localhost:8080")
+        let ep = try KasEndpoints.from(filled)
+        XCTAssertEqual(ep.transport, .connect)
+    }
+
     func testFromConfigThrowsWhenUriEmpty() {
         let cfg = OpenTDFConfiguration(
             kas: KasConfig(uri: "", algorithms: [],

--- a/OpenTDFKitTests/KASRewrapClientTests.swift
+++ b/OpenTDFKitTests/KASRewrapClientTests.swift
@@ -33,7 +33,8 @@ final class KASRewrapClientTests: XCTestCase {
               "kasWrappedKey": "dGVzdA==",
               "metadata": {
                 "error": "none",
-                "X-Required-Obligations": ["https://example.com/obl/a", "https://example.com/obl/b"]
+                "X-Required-Obligations": ["https://example.com/obl/a", "https://example.com/obl/b"],
+                "count": 2
               }
             }]
           }],
@@ -47,6 +48,8 @@ final class KASRewrapClientTests: XCTestCase {
         let result = try XCTUnwrap(response.responses.first?.results.first)
         XCTAssertEqual(result.status, "permit")
         XCTAssertEqual(result.metadata?["error"]?.stringValue, "none")
+        // Integral JSON numbers must not render as "2.0"
+        XCTAssertEqual(result.metadata?["count"]?.stringValue, "2")
         if case let .array(vals)? = result.metadata?["X-Required-Obligations"] {
             XCTAssertEqual(vals.count, 2)
         } else {

--- a/OpenTDFKitTests/KASRewrapClientTests.swift
+++ b/OpenTDFKitTests/KASRewrapClientTests.swift
@@ -20,6 +20,40 @@ final class KASRewrapClientTests: XCTestCase {
         super.tearDown()
     }
 
+    func testRewrapMetadataDecodesArrayValues() throws {
+        // Platform returns X-Required-Obligations as a JSON array; [String:String]
+        // decoding used to fail the whole rewrap response.
+        let json = """
+        {
+          "responses": [{
+            "policyId": "policy",
+            "results": [{
+              "keyAccessObjectId": "kao-0",
+              "status": "permit",
+              "kasWrappedKey": "dGVzdA==",
+              "metadata": {
+                "error": "none",
+                "X-Required-Obligations": ["https://example.com/obl/a", "https://example.com/obl/b"]
+              }
+            }]
+          }],
+          "sessionPublicKey": "-----BEGIN PUBLIC KEY-----\\nMFkwEwYH\\n-----END PUBLIC KEY-----"
+        }
+        """
+        let response = try JSONDecoder().decode(
+            KASRewrapClient.RewrapResponse.self,
+            from: Data(json.utf8),
+        )
+        let result = try XCTUnwrap(response.responses.first?.results.first)
+        XCTAssertEqual(result.status, "permit")
+        XCTAssertEqual(result.metadata?["error"]?.stringValue, "none")
+        if case let .array(vals)? = result.metadata?["X-Required-Obligations"] {
+            XCTAssertEqual(vals.count, 2)
+        } else {
+            XCTFail("expected array metadata for X-Required-Obligations")
+        }
+    }
+
     func testJWTSigningWithValidKey() throws {
         let signingKey = P256.Signing.PrivateKey()
         let requestBody = "test request body".data(using: .utf8)!

--- a/OpenTDFKitTests/TDFTests.swift
+++ b/OpenTDFKitTests/TDFTests.swift
@@ -45,27 +45,35 @@ final class StandardTDFTests: XCTestCase {
         XCTAssertFalse(binding.alg.isEmpty, "Policy binding algorithm should not be empty")
         XCTAssertFalse(binding.hash.isEmpty, "Policy binding hash should not be empty")
         XCTAssertEqual(binding.alg, "HS256")
-        // Go/python format: base64(hex(HMAC(base64(policyJSON)))) → 88 chars of base64
+        // Go format: base64(hex(HMAC(base64(policyJSON)))) → 88 chars of base64
         // (64 hex chars of HMAC-SHA256 → 88 base64 chars with padding).
         XCTAssertEqual(binding.hash.count, 88, "OpenTDF policy binding hash is base64(hex(hmac))")
         // Must decode as base64 of a 64-char hex string, not raw 32-byte HMAC.
         let hashData = try XCTUnwrap(Data(base64Encoded: binding.hash))
         let hex = try XCTUnwrap(String(data: hashData, encoding: .utf8))
         XCTAssertEqual(hex.count, 64)
-        XCTAssertTrue(hex.allSatisfy { $0.isHexDigit })
+        XCTAssertTrue(hex.allSatisfy(\.isHexDigit))
     }
 
-    func testPolicyBindingMatchesGoFormatVector() throws {
+    func testPolicyBindingMatchesGoFormatVector() {
         // Fixed DEK + policy so we can lock the go/rust/python wire format.
         let keyBytes = Data(repeating: 0x30, count: 32) // ASCII '0' * 32
         let symmetricKey = SymmetricKey(data: keyBytes)
         let policyJSON = #"{"uuid":"u","body":{"dataAttributes":[],"dissem":[]}}"#.data(using: .utf8)!
         let binding = TDFCrypto.policyBinding(policy: policyJSON, symmetricKey: symmetricKey)
-        // Python/rust: base64(hex(HMAC-SHA256(key, base64(policy))))
+        // Go: base64(hex(HMAC-SHA256(key, base64(policy))))
         XCTAssertEqual(
             binding.hash,
             "OGE3MDAyNmI3OWFiMWVhMTYyMzU4MWViN2E5MmEwNzlmYzJkNWU1OTFhZmU5M2JlMTE3YWJiYjVhYjY5YTE3Yg==",
         )
+    }
+
+    func testStandardTDFSessionSaltIsSHA256OfTDF() {
+        // go SDK tdfSalt(): sha256.Sum256([]byte("TDF"))
+        var hasher = SHA256()
+        hasher.update(data: Data("TDF".utf8))
+        let expected = Data(hasher.finalize())
+        XCTAssertEqual(KASRewrapClient.standardTDFSessionSalt, expected)
     }
 
     func testSegmentSignature() throws {

--- a/OpenTDFKitTests/TDFTests.swift
+++ b/OpenTDFKitTests/TDFTests.swift
@@ -44,6 +44,28 @@ final class StandardTDFTests: XCTestCase {
 
         XCTAssertFalse(binding.alg.isEmpty, "Policy binding algorithm should not be empty")
         XCTAssertFalse(binding.hash.isEmpty, "Policy binding hash should not be empty")
+        XCTAssertEqual(binding.alg, "HS256")
+        // Go/python format: base64(hex(HMAC(base64(policyJSON)))) → 88 chars of base64
+        // (64 hex chars of HMAC-SHA256 → 88 base64 chars with padding).
+        XCTAssertEqual(binding.hash.count, 88, "OpenTDF policy binding hash is base64(hex(hmac))")
+        // Must decode as base64 of a 64-char hex string, not raw 32-byte HMAC.
+        let hashData = try XCTUnwrap(Data(base64Encoded: binding.hash))
+        let hex = try XCTUnwrap(String(data: hashData, encoding: .utf8))
+        XCTAssertEqual(hex.count, 64)
+        XCTAssertTrue(hex.allSatisfy { $0.isHexDigit })
+    }
+
+    func testPolicyBindingMatchesGoFormatVector() throws {
+        // Fixed DEK + policy so we can lock the go/rust/python wire format.
+        let keyBytes = Data(repeating: 0x30, count: 32) // ASCII '0' * 32
+        let symmetricKey = SymmetricKey(data: keyBytes)
+        let policyJSON = #"{"uuid":"u","body":{"dataAttributes":[],"dissem":[]}}"#.data(using: .utf8)!
+        let binding = TDFCrypto.policyBinding(policy: policyJSON, symmetricKey: symmetricKey)
+        // Python/rust: base64(hex(HMAC-SHA256(key, base64(policy))))
+        XCTAssertEqual(
+            binding.hash,
+            "OGE3MDAyNmI3OWFiMWVhMTYyMzU4MWViN2E5MmEwNzlmYzJkNWU1OTFhZmU5M2JlMTE3YWJiYjVhYjY5YTE3Yg==",
+        )
     }
 
     func testSegmentSignature() throws {

--- a/OpenTDFKitTests/TDFTests.swift
+++ b/OpenTDFKitTests/TDFTests.swift
@@ -76,6 +76,33 @@ final class StandardTDFTests: XCTestCase {
         XCTAssertEqual(KASRewrapClient.standardTDFSessionSalt, expected)
     }
 
+    func testSegmentGMACIsLast16BytesOfEncryptedSegment() throws {
+        // go calculateSignature(GMAC, hexless): last 16 bytes of segment (AES-GCM tag).
+        let tag = Data((0 ..< 16).map { UInt8($0) })
+        let encrypted = Data(repeating: 0xAB, count: 40) + tag
+        let gmac = try TDFCrypto.segmentSignatureGMAC(encryptedSegment: encrypted)
+        XCTAssertEqual(gmac, tag)
+        XCTAssertEqual(
+            try TDFCrypto.segmentHashBase64GMAC(encryptedSegment: encrypted),
+            tag.base64EncodedString(),
+        )
+    }
+
+    func testRootSignatureIsHMACOfConcatenatedRawSegmentSigs() throws {
+        let key = try TDFCrypto.generateSymmetricKey()
+        let s1 = Data(repeating: 0x11, count: 16)
+        let s2 = Data(repeating: 0x22, count: 16)
+        let root = TDFCrypto.rootSignatureBase64(rawSegmentSignatures: [s1, s2], symmetricKey: key)
+        let expected = TDFCrypto.segmentSignature(
+            segmentCiphertext: s1 + s2,
+            symmetricKey: key,
+        ).base64EncodedString()
+        XCTAssertEqual(root, expected)
+        // Hexless: root is base64 of raw HMAC (not base64(hex(...)))
+        let raw = try XCTUnwrap(Data(base64Encoded: root))
+        XCTAssertEqual(raw.count, 32)
+    }
+
     func testSegmentSignature() throws {
         let symmetricKey = try TDFCrypto.generateSymmetricKey()
         let segmentData = "Segment data".data(using: .utf8)!

--- a/xtest/cli.swift
+++ b/xtest/cli.swift
@@ -81,8 +81,11 @@ enum Command {
 
     enum TDFFormat: String {
         case nano
-        case ztdf
-        case ztdfECWrap = "ztdf-ecwrap"
+        case tdf
+        /// Legacy wire name for Base TDF ZIP (accepted as synonym for `tdf`).
+        case tdfLegacy = "ztdf"
+        case tdfECWrap = "tdf-ecwrap"
+        case tdfECWrapLegacy = "ztdf-ecwrap"
         case nanoWithECDSA = "nano-with-ecdsa"
     }
 }
@@ -170,9 +173,9 @@ func handleEncrypt(plaintext: String, ciphertext: String, format: Command.TDFFor
 
         encryptedData = try nanoTDF.serialize()
 
-    case .ztdf, .ztdfECWrap:
-        // ZTDF not yet implemented
-        print("ZTDF format not yet implemented in Swift SDK")
+    case .tdf, .tdfLegacy, .tdfECWrap, .tdfECWrapLegacy:
+        // Prefer OpenTDFKitCLI for Base TDF; this stub is nano-only.
+        print("Base TDF format: use OpenTDFKitCLI (not this stub)")
         exit(1)
     }
 
@@ -203,8 +206,8 @@ func handleDecrypt(ciphertext: String, recovered: String, format: Command.TDFFor
         // For testing, return a placeholder
         decryptedData = "Decryption requires KAS integration".data(using: .utf8)!
 
-    case .ztdf, .ztdfECWrap:
-        print("ZTDF format not yet implemented in Swift SDK")
+    case .tdf, .tdfLegacy, .tdfECWrap, .tdfECWrapLegacy:
+        print("Base TDF format: use OpenTDFKitCLI (not this stub)")
         exit(1)
     }
 


### PR DESCRIPTION
## Summary
- **Bugfix:** When `/.well-known/opentdf-configuration` returns 200 without a usable `kas` block, fall back to Connect endpoints on the default KAS base (`PLATFORMURL` / stripped `KASURL`) instead of failing with `well-known configuration is missing a 'kas' block`.
- **CI:** New `X-Test Stage-1` workflow pulls **floating latest** release of `arkavo-org/opentdf-tests` (falls back to `community-xtest-stage1` if no release) and runs swift × go Base TDF stage1 on macOS with the native platform stack.

## Cross-repo coordination
| Direction | Pin |
|---|---|
| OpenTDFKit → tests | `tests-ref: latest` → [community-xtest-stage1-v0.1.0](https://github.com/arkavo-org/opentdf-tests/releases/tag/community-xtest-stage1-v0.1.0) (created) |
| tests → OpenTDFKit | community-xtest floats `swift-ref: latest`; until a post-fix OpenTDFKit release, use `swift-ref: main` / this PR SHA for green Stage-1 |

After merge, cut an OpenTDFKit release (or keep community-xtest on `main`) so floating `latest` includes this fallback.

## Test plan
- [x] `swift test --filter KASDiscoveryTests` (24 tests, 0 failures)
- [ ] CI `X-Test Stage-1` on this PR
- [ ] community-xtest swift job with `swift-ref` = this SHA or main after merge

----
## Summary by Gitar

- **TDF Crypto:**
  - Updated `policyBinding` to encode HMAC-SHA256 of the base64-encoded policy, fixing interoperability with the Go SDK.
  - Set `wrapSymmetricKeyWithRSA` to use `RSA-OAEP-SHA1` for alignment with existing KAS unwrap expectations.
  - Standardized segment integrity (GMAC) to use the last 16 bytes of the encrypted segment (AES-GCM tag).
  - Updated `TDFEncryptor` to use new hexless 4.3.0 root signature logic (`base64(HMAC-SHA256(DEK, concat(raw segment sigs)))`).
- **CLI Improvements:**
  - Improved OAuth token requests by normalizing `localhost` to `127.0.0.1` and applying strict form-urlencoding.
  - Added `XT_WITH_ATTRIBUTES` support for injecting FQN-based attribute objects during CLI TDF policy generation.
- **KAS Metadata:**
  - Introduced `RewrapMetadataValue` enum to handle heterogeneous metadata (strings, arrays, objects) in rewrap responses.
- **KAS Discovery:**
  - Implemented `withKasFallback` to automatically synthesize platform Connect endpoints when well-known configuration is incomplete.
- **CI/CD:**
  - Added `xtest.yml` for Stage-1 cross-testing between the Swift SDK and the Go platform peer.

<sub>This will update automatically on new commits.</sub>